### PR TITLE
indent, fix/unify extrapolation bounds, introduce `TriangulationType` in application

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
@@ -1247,8 +1247,7 @@ public:
         std::sort(it->second.begin(),
                   it->second.end(),
                   [](const std::array<types::global_dof_index, 5> & a,
-                     const std::array<types::global_dof_index, 5> & b)
-                  {
+                     const std::array<types::global_dof_index, 5> & b) {
                     if(a[4] < b[4])
                       return true;
                     else if(a[4] == b[4] && a[3] < b[3])
@@ -1269,8 +1268,7 @@ public:
         std::sort(it->second.begin(),
                   it->second.end(),
                   [](const std::array<types::global_dof_index, 5> & a,
-                     const std::array<types::global_dof_index, 5> & b)
-                  {
+                     const std::array<types::global_dof_index, 5> & b) {
                     if(a[1] < b[1])
                       return true;
                     else if(a[1] == b[1] && a[2] < b[2])
@@ -2915,8 +2913,7 @@ private:
           }
           const unsigned int face_idx = cell->face(2 * d + 1)->index();
 
-          const auto add_entry = [&](const unsigned int position)
-          {
+          const auto add_entry = [&](const unsigned int position) {
             const unsigned int entry_within_vector = position / 64;
             const unsigned int bit_within_entry    = position % 64;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator_rt.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator_rt.h
@@ -263,9 +263,7 @@ allocate_shared_recv_data(MemorySpace::MemorySpaceData<Number, MemorySpace::Host
   // Kokkos will not free the memory because the memory is
   // unmanaged. Instead we use a shared pointer to take care of
   // that.
-  data.values_sm_ptr = {ptr_aligned,
-                        [mpi_window](Number *) mutable
-                        {
+  data.values_sm_ptr = {ptr_aligned, [mpi_window](Number *) mutable {
                           // note: we are creating here a copy of
                           // the window other approaches led to
                           // segmentation faults
@@ -543,8 +541,7 @@ public:
         std::sort(it->second.begin(),
                   it->second.end(),
                   [](const std::array<types::global_dof_index, 5> & a,
-                     const std::array<types::global_dof_index, 5> & b)
-                  {
+                     const std::array<types::global_dof_index, 5> & b) {
                     if(a[4] < b[4])
                       return true;
                     else if(a[4] == b[4] && a[3] < b[3])
@@ -565,8 +562,7 @@ public:
         std::sort(it->second.begin(),
                   it->second.end(),
                   [](const std::array<types::global_dof_index, 5> & a,
-                     const std::array<types::global_dof_index, 5> & b)
-                  {
+                     const std::array<types::global_dof_index, 5> & b) {
                     if(a[1] < b[1])
                       return true;
                     else if(a[1] == b[1] && a[2] < b[2])
@@ -3344,7 +3340,7 @@ private:
         {
           const VectorizedArray<Number> val[2] = {quad_values[q1 * dim], quad_values[q1 * dim + 1]};
           const VectorizedArray<Number> grad[2][2]  = {{grad_x[qx * dim], grad_x[qx * dim + 1]},
-                                                       {grad_y[q1 * dim], grad_y[q1 * dim + 1]}};
+                                                      {grad_y[q1 * dim], grad_y[q1 * dim + 1]}};
           const VectorizedArray<Number> t0          = jac_xy[0][0] * val[0] + jac_xy[0][1] * val[1];
           const VectorizedArray<Number> t1          = jac_xy[1][0] * val[0] + jac_xy[1][1] * val[1];
           VectorizedArray<Number>       val_real[2] = {t0, t1};
@@ -3450,8 +3446,8 @@ private:
             const unsigned int            iy         = dim * (qz * nn + qy * nn * nn + qx);
             const unsigned int            iz         = dim * qz;
             const VectorizedArray<Number> val[3]     = {quad_values[q * dim],
-                                                        quad_values[q * dim + 1],
-                                                        quad_values[q * dim + 2]};
+                                                    quad_values[q * dim + 1],
+                                                    quad_values[q * dim + 2]};
             const VectorizedArray<Number> grad[3][3] = {
               {grad_x[ix + 0], grad_y[iy + 0], grad_z[iz + 0]},
               {grad_x[ix + 1], grad_y[iy + 1], grad_z[iz + 1]},
@@ -5189,7 +5185,7 @@ private:
         if constexpr(dim == 2)
         {
           const VectorizedArray<Number> val[2]     = {quad_values[0][q1 * dim],
-                                                      quad_values[0][q1 * dim + 1]};
+                                                  quad_values[0][q1 * dim + 1]};
           const VectorizedArray<Number> grad[2][2] = {{grad_x[qx * dim], grad_x[qx * dim + 1]},
                                                       {quad_values[1][q1 * dim],
                                                        quad_values[1][q1 * dim + 1]}};
@@ -5239,8 +5235,8 @@ private:
             const unsigned int            ix         = dim * (qz + qx * nn);
             const unsigned int            iz         = dim * qz;
             const VectorizedArray<Number> val[3]     = {quad_values[0][q * dim],
-                                                        quad_values[0][q * dim + 1],
-                                                        quad_values[0][q * dim + 2]};
+                                                    quad_values[0][q * dim + 1],
+                                                    quad_values[0][q * dim + 2]};
             const VectorizedArray<Number> grad[3][3] = {
               {grad_x[ix + 0], quad_values[1][q * dim + 0], grad_z[iz + 0]},
               {grad_x[ix + 1], quad_values[1][q * dim + 1], grad_z[iz + 1]},
@@ -5424,8 +5420,8 @@ private:
         for(unsigned int qz = 0, q = q1; qz < nn; ++qz, q += nn)
         {
           const VectorizedArray<Number> val[3]     = {values_face[0][0][q],
-                                                      values_face[0][1][q],
-                                                      values_face[0][2][q]};
+                                                  values_face[0][1][q],
+                                                  values_face[0][2][q]};
           const VectorizedArray<Number> grad[3][3] = {{grads_face[0][0][q * dim],
                                                        grads_face[0][0][q * dim + 1],
                                                        grads_face[0][0][q * dim + 2]},
@@ -5656,8 +5652,7 @@ private:
           }
           const unsigned int face_idx = cell->face(2 * d + 1)->index();
 
-          const auto add_entry = [&](const unsigned int position)
-          {
+          const auto add_entry = [&](const unsigned int position) {
             const unsigned int entry_within_vector = position / 64;
             const unsigned int bit_within_entry    = position % 64;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
@@ -211,8 +211,10 @@ public:
 
       dealii::SolverCG<VectorType>        solver(control);
       dealii::internal::EigenvalueTracker eigenvalue_tracker;
-      solver.connect_eigenvalues_slot([&eigenvalue_tracker](const std::vector<double> & eigenvalues)
-                                      { eigenvalue_tracker.slot(eigenvalues); });
+      solver.connect_eigenvalues_slot(
+        [&eigenvalue_tracker](const std::vector<double> & eigenvalues) {
+          eigenvalue_tracker.slot(eigenvalues);
+        });
 
       mg_matrices[level].initialize_dof_vector(solution_update[level]);
       mg_matrices[level].initialize_dof_vector(temp_vector[level]);
@@ -257,8 +259,10 @@ public:
 
       dealii::SolverCG<VectorType>        solver(control);
       dealii::internal::EigenvalueTracker eigenvalue_tracker;
-      solver.connect_eigenvalues_slot([&eigenvalue_tracker](const std::vector<double> & eigenvalues)
-                                      { eigenvalue_tracker.slot(eigenvalues); });
+      solver.connect_eigenvalues_slot(
+        [&eigenvalue_tracker](const std::vector<double> & eigenvalues) {
+          eigenvalue_tracker.slot(eigenvalues);
+        });
 
       dg_matrix.initialize_dof_vector(solution_update_dg);
       dg_matrix.initialize_dof_vector(rhs_dg);

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting.cpp
@@ -401,7 +401,7 @@ TimeIntBDFDualSplitting<dim, Number>::convective_step()
     }
 
     velocity_np.equ(-this->extra.get_beta(0), this->vec_convective_term[0]);
-    for(unsigned int i = 1; i < this->vec_convective_term.size(); ++i)
+    for(unsigned int i = 1; i < this->extra.get_order(); ++i)
       velocity_np.add(-this->extra.get_beta(i), this->vec_convective_term[i]);
   }
   else
@@ -493,7 +493,7 @@ TimeIntBDFDualSplitting<dim, Number>::pressure_step()
   if(this->use_extrapolation)
   {
     pressure_np.equ(this->extra.get_beta(0), pressure[0]);
-    for(unsigned int i = 1; i < pressure.size(); ++i)
+    for(unsigned int i = 1; i < this->extra.get_order(); ++i)
     {
       pressure_np.add(this->extra.get_beta(i), pressure[i]);
     }
@@ -563,7 +563,7 @@ TimeIntBDFDualSplitting<dim, Number>::rhs_pressure(VectorType & rhs) const
     // convective term
     if(this->param.convective_problem())
     {
-      for(unsigned int i = 0; i < velocity.size(); ++i)
+      for(unsigned int i = 0; i < this->extra.get_order(); ++i)
       {
         temp = 0.0;
         pde_operator->rhs_ppe_div_term_convective_term_add(temp, velocity[i]);
@@ -686,7 +686,7 @@ TimeIntBDFDualSplitting<dim, Number>::projection_step()
     if(this->use_extrapolation)
     {
       velocity_extrapolated.reinit(velocity[0]);
-      for(unsigned int i = 0; i < velocity.size(); ++i)
+      for(unsigned int i = 0; i < this->extra.get_order(); ++i)
         velocity_extrapolated.add(this->extra.get_beta(i), velocity[i]);
     }
     else
@@ -777,7 +777,7 @@ TimeIntBDFDualSplitting<dim, Number>::viscous_step()
     if(this->use_extrapolation)
     {
       velocity_np.equ(this->extra.get_beta(0), velocity[0]);
-      for(unsigned int i = 1; i < velocity.size(); ++i)
+      for(unsigned int i = 1; i < this->extra.get_order(); ++i)
         velocity_np.add(this->extra.get_beta(i), velocity[i]);
     }
     else
@@ -1001,7 +1001,7 @@ TimeIntBDFDualSplitting<dim, Number>::rhs_viscous(VectorType &       rhs,
   // dual-splitting scheme
   if(this->param.non_explicit_convective_problem())
   {
-    for(unsigned int i = 0; i < this->vec_convective_term.size(); ++i)
+    for(unsigned int i = 0; i < this->extra.get_order(); ++i)
       rhs.add(this->extra.get_beta(i), this->vec_convective_term[i]);
   }
 
@@ -1038,7 +1038,7 @@ TimeIntBDFDualSplitting<dim, Number>::residual_rhs_viscous(
   // dual-splitting scheme
   if(this->param.non_explicit_convective_problem())
   {
-    for(unsigned int i = 0; i < this->vec_convective_term.size(); ++i)
+    for(unsigned int i = 0; i < this->extra.get_order(); ++i)
     {
       rhs.add(this->extra.get_beta(i), this->vec_convective_term[i]);
     }
@@ -1064,7 +1064,7 @@ TimeIntBDFDualSplitting<dim, Number>::penalty_step()
     VectorType velocity_extrapolated;
     velocity_extrapolated.reinit(velocity_np, true /* omit_zeroing_entries */);
     velocity_extrapolated.equ(this->extra.get_beta(0), velocity[0]);
-    for(unsigned int i = 1; i < velocity.size(); ++i)
+    for(unsigned int i = 1; i < this->extra.get_order(); ++i)
       velocity_extrapolated.add(this->extra.get_beta(i), velocity[i]);
 
     pde_operator->update_projection_operator(velocity_extrapolated, this->get_time_step_size());

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting_extruded.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting_extruded.cpp
@@ -917,7 +917,7 @@ TimeIntBDFDualSplittingExtruded<dim, Number>::convective_step()
       }
     }
 
-    for(unsigned int i = 0; i < factors.size(); ++i)
+    for(unsigned int i = 0; i < this->extra.get_order(); ++i)
       factors[i] = -this->extra.get_beta(i);
     extrapolate_vectors(factors, this->vec_convective_term, rhs_rt);
   }
@@ -942,7 +942,7 @@ TimeIntBDFDualSplittingExtruded<dim, Number>::convective_step()
 
   dealii::SolverCG<VectorType> solver_cg(control);
   op_rt->set_parameters(1.0, 0.0);
-  for(unsigned int i = 0; i < solutions_convective.size(); ++i)
+  for(unsigned int i = 0; i < this->extra.get_order(); ++i)
     factors[i] = this->extra.get_beta(i);
   extrapolate_vectors(factors, solutions_convective, solutions_convective.back());
   solver_cg.solve(*op_rt, solutions_convective.back(), rhs_rt, preconditioner_mass);


### PR DESCRIPTION
.) I accidentally ran the indentation script
.) I introduced the `TriangulationType` to make restart easier
.) The standard `BDFDualSplitting` asserts trying to access extrapolation constants since the `velocities` vector is now fixed to a size of 4 (idk why). But `BDFDualSplitting` also does not work with this fix here, there are some other bugs. Do we even need this time integration scheme? I would not fix this for now.

I also tested restart again and it does not work. I have to see how I can fix this.