### PR TITLE
fix restart for `BDFConsistentSplittingExtruded`

### DIFF
--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -424,7 +424,7 @@ private:
         {
           // need to adjust for hierarchic numbering of
           // dealii::MappingQCache
-          points_moved[i] = manifold.push_forward(
+          points_moved[i] = ( // manifold.push_forward(
             fe_values.quadrature_point(hierarchic_to_lexicographic_numbering[i]));
         }
 
@@ -439,7 +439,7 @@ private:
       {
         // need to adjust for hierarchic numbering of
         // dealii::MappingQCache
-        points_moved[i] = manifold.push_forward(cell->vertex(i));
+        points_moved[i] = cell->vertex(i); // manifold.push_forward(cell->vertex(i));
       }
 
       return points_moved;

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -206,12 +206,13 @@ private:
     this->param.start_with_low_order            = read_restart ? false : true;
 
     // output of solver information
-    this->param.solver_info_data.interval_time = flow_through_time / 10.0;
+    this->param.solver_info_data.interval_time = flow_through_time / 10000000000000.0;
 
     // SPATIAL DISCRETIZATION
-    this->param.spatial_discretization      = spatial_discretization;
-    this->param.grid.triangulation_type     = triangulation_type;
-    this->param.mapping_degree              = this->param.degree_u;
+    this->param.spatial_discretization                 = spatial_discretization;
+    this->param.grid.triangulation_type                = triangulation_type;
+    bool constexpr stable_restart_fixed_mapping_degree = true;
+    this->param.mapping_degree = stable_restart_fixed_mapping_degree ? 3 : this->param.degree_u;
     this->param.mapping_degree_coarse_grids = this->param.mapping_degree;
     this->param.degree_p                    = DegreePressure::MixedOrder;
 
@@ -248,13 +249,15 @@ private:
     this->param.restarted_simulation       = read_restart;
     this->param.restart_data.write_restart = write_restart;
     // write restart every 40% of the simulation time
-    this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.4;
+    this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.01;
     this->param.restart_data.directory_coarse_triangulation = this->output_parameters.directory;
     this->param.restart_data.directory                      = this->output_parameters.directory;
     this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
     this->param.restart_data.interval_wall_time  = 1.e6;
     this->param.restart_data.interval_time_steps = 1e8;
 
+    // Same `mapping_degree` and spatial resolution are the most stable options for restart,
+    // polynomial degree can be varied.
     this->param.restart_data.discretization_identical                        = false;
     this->param.restart_data.consider_mapping_write                          = true;
     this->param.restart_data.consider_mapping_read_source                    = true;

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -249,7 +249,7 @@ private:
     this->param.restarted_simulation       = read_restart;
     this->param.restart_data.write_restart = write_restart;
     // write restart every 40% of the simulation time
-    this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.01;
+    this->param.restart_data.interval_time = (this->param.end_time - this->param.start_time) * 0.8;
     this->param.restart_data.directory_coarse_triangulation = this->output_parameters.directory;
     this->param.restart_data.directory                      = this->output_parameters.directory;
     this->param.restart_data.filename            = this->output_parameters.filename + "_restart";
@@ -258,7 +258,6 @@ private:
 
     // Same `mapping_degree` and spatial resolution are the most stable options for restart,
     // polynomial degree can be varied.
-    this->param.restart_data.discretization_identical                        = false;
     this->param.restart_data.consider_mapping_write                          = true;
     this->param.restart_data.consider_mapping_read_source                    = true;
     this->param.restart_data.consider_restart_time_in_mesh_movement_function = true;

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -206,13 +206,12 @@ private:
     this->param.start_with_low_order            = read_restart ? false : true;
 
     // output of solver information
-    this->param.solver_info_data.interval_time = flow_through_time / 10000000000000.0;
+    this->param.solver_info_data.interval_time = flow_through_time / 100.0;
 
     // SPATIAL DISCRETIZATION
-    this->param.spatial_discretization                 = spatial_discretization;
-    this->param.grid.triangulation_type                = triangulation_type;
-    bool constexpr stable_restart_fixed_mapping_degree = true;
-    this->param.mapping_degree = stable_restart_fixed_mapping_degree ? 3 : this->param.degree_u;
+    this->param.spatial_discretization      = spatial_discretization;
+    this->param.grid.triangulation_type     = triangulation_type;
+    this->param.mapping_degree              = this->param.degree_u;
     this->param.mapping_degree_coarse_grids = this->param.mapping_degree;
     this->param.degree_p                    = DegreePressure::MixedOrder;
 
@@ -423,7 +422,7 @@ private:
         {
           // need to adjust for hierarchic numbering of
           // dealii::MappingQCache
-          points_moved[i] = ( // manifold.push_forward(
+          points_moved[i] = manifold.push_forward(
             fe_values.quadrature_point(hierarchic_to_lexicographic_numbering[i]));
         }
 
@@ -438,7 +437,7 @@ private:
       {
         // need to adjust for hierarchic numbering of
         // dealii::MappingQCache
-        points_moved[i] = cell->vertex(i); // manifold.push_forward(cell->vertex(i));
+        points_moved[i] = manifold.push_forward(cell->vertex(i));
       }
 
       return points_moved;

--- a/applications/incompressible_navier_stokes/periodic_hill/input_reference.json
+++ b/applications/incompressible_navier_stokes/periodic_hill/input_reference.json
@@ -18,7 +18,7 @@
         "TriangulationType": "Serial",
         "ReadRestart": "false",
         "WriteRestart": "true",
-        "TemporalDiscretization": "BDFDualSplittingExtruded",
+        "TemporalDiscretization": "BDFConsistentSplittingExtruded",
         "SpatialDiscretization": "HDIV",
         "Inviscid": "false",
         "ReynoldsNumber": "5600.0e-3",

--- a/applications/incompressible_navier_stokes/periodic_hill/input_restart.json
+++ b/applications/incompressible_navier_stokes/periodic_hill/input_restart.json
@@ -15,7 +15,7 @@
         "RefineTimeMax": "0"
     },
     "Application": {
-        "TriangulationType": "Serial",
+        "TriangulationType": "Distributed",
         "ReadRestart": "true",
         "WriteRestart": "false",
         "TemporalDiscretization": "BDFConsistentSplittingExtruded",

--- a/applications/incompressible_navier_stokes/periodic_hill/input_restart.json
+++ b/applications/incompressible_navier_stokes/periodic_hill/input_restart.json
@@ -18,7 +18,7 @@
         "TriangulationType": "Serial",
         "ReadRestart": "true",
         "WriteRestart": "false",
-        "TemporalDiscretization": "BDFDualSplittingExtruded",
+        "TemporalDiscretization": "BDFConsistentSplittingExtruded",
         "SpatialDiscretization": "HDIV",
         "Inviscid": "false",
         "ReynoldsNumber": "5600.0e-3",

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -135,12 +135,18 @@ template<int dim, typename Number>
 void
 OperatorCoupled<dim, Number>::update_divergence_penalty_operator(VectorType const & velocity)
 {
+  AssertThrow(false,
+              dealii::ExcMessage("This function is empty. Should it be filled or should we "
+                                 "put a comment here saying that no update is necessary?"));
 }
 
 template<int dim, typename Number>
 void
 OperatorCoupled<dim, Number>::update_continuity_penalty_operator(VectorType const & velocity)
 {
+  AssertThrow(false,
+              dealii::ExcMessage("This function is empty. Should it be filled or should we "
+                                 "put a comment here saying that no update is necessary?"));
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1114,7 +1114,7 @@ SpatialOperatorBase<dim, Number>::serialize_vectors(
   // We use `dealii::DoFRenumbering::matrix_free_data_locality()` such that the DoF ordering depends
   // on the MPI ranks used, operator and constraints. Therefore, we need to de-/serialize using an
   // unordered `dealii::DoFHandler`. An element-wise continuous space with support points in Gauss
-  // points yields a diagonal mass matrix.
+  // points yields a diagonal mass matrix and is hence a good candidate.
 
   // Go from the current FE and ordering to the one to be de-serialized.
   if(dof_handler_restart_setup_for_writing == false)
@@ -1208,8 +1208,6 @@ SpatialOperatorBase<dim, Number>::serialize_vectors(
                                                  dof_handlers,
                                                  vectors_per_dof_handler);
   }
-
-  AssertThrow(false, dealii::ExcMessage("ENDPOINT REACHED, SOLUTION WRITTEN."));
 }
 
 template<int dim, typename Number>
@@ -1231,7 +1229,7 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
                                    deserialization_parameters.triangulation_type,
                                    mpi_comm);
 
-  // Set up DoFHandlers *as checkpointed*, sequence matches `this->serialize_vectors()`.
+  // Set up `DoFHandlers` *as checkpointed*, sequence matches `this->serialize_vectors()`.
   initialize_dof_handler_restart(deserialization_parameters.degree_u,
                                  deserialization_parameters.degree_p,
                                  *checkpoint_triangulation);
@@ -1258,7 +1256,7 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
   if(param.restart_data.discretization_identical)
   {
     AssertThrow(param.restart_data.discretization_identical,
-                dealii::ExcMessage("Since we project onto `FE_DGQArbitraryNodes`, we require"
+                dealii::ExcMessage("Since we project onto `FE_DGQArbitraryNodes`, we require "
                                    "the projection onto the currently used FE space."));
   }
   else

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -543,12 +543,20 @@ private:
   std::shared_ptr<dealii::FiniteElement<dim>> fe_u;
   std::shared_ptr<dealii::FiniteElement<dim>> fe_p;
   std::shared_ptr<dealii::FiniteElement<dim>> fe_u_scalar;
-  std::shared_ptr<dealii::FiniteElement<dim>> fe_mapping;
 
-  dealii::DoFHandler<dim>                  dof_handler_u;
-  dealii::DoFHandler<dim>                  dof_handler_p;
-  dealii::DoFHandler<dim>                  dof_handler_u_scalar;
-  std::shared_ptr<dealii::DoFHandler<dim>> dof_handler_mapping;
+  std::shared_ptr<dealii::FiniteElement<dim>>         fe_mapping;
+  mutable std::shared_ptr<dealii::FiniteElement<dim>> fe_u_restart;
+  mutable std::shared_ptr<dealii::FiniteElement<dim>> fe_p_restart;
+
+  dealii::DoFHandler<dim> dof_handler_u;
+  dealii::DoFHandler<dim> dof_handler_p;
+  dealii::DoFHandler<dim> dof_handler_u_scalar;
+
+  mutable bool dof_handler_restart_setup_for_writing = false;
+
+  mutable std::shared_ptr<dealii::DoFHandler<dim>> dof_handler_u_restart;
+  mutable std::shared_ptr<dealii::DoFHandler<dim>> dof_handler_p_restart;
+  std::shared_ptr<dealii::DoFHandler<dim>>         dof_handler_mapping;
 
   dealii::AffineConstraints<Number> constraint_u, constraint_p, constraint_u_scalar;
 
@@ -670,6 +678,17 @@ private:
 
   void
   initialize_dof_handler_and_constraints();
+
+  void
+  initialize_dof_handler_restart(unsigned int const                 degree_u,
+                                 unsigned int const                 degree_p,
+                                 dealii::Triangulation<dim> const & triangulation) const;
+
+  void
+  project_standard_to_restart(VectorType const &              src_standard,
+                              dealii::DoFHandler<dim> const & src_dof_handler_standard,
+                              VectorType &                    dst_restart,
+                              dealii::DoFHandler<dim> const & dst_dof_handler_restart) const;
 
   void
   initialize_dirichlet_cached_bc();

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.cpp
@@ -328,7 +328,6 @@ TimeIntBDF<dim, Number>::read_restart_vectors()
   {
     vectors_velocity_ptr.push_back(&vectors_velocity[i]);
   }
-
   for(unsigned int i = 0; i < this->get_size_pressure(); i++)
   {
     vectors_pressure_ptr.push_back(&vectors_pressure[i]);
@@ -395,7 +394,7 @@ TimeIntBDF<dim, Number>::read_restart_vectors()
     {
       for(unsigned int i = 0; i < this->order; i++)
       {
-        this->copy_from_vec_convective_term_for_restart(i);
+        copy_from_vec_convective_term_for_restart(i);
       }
     }
   }
@@ -470,7 +469,7 @@ TimeIntBDF<dim, Number>::write_restart_vectors() const
       for(unsigned int i = 0; i < this->order; i++)
       {
         // Copy the vector to the standard matrix-free format.
-        this->copy_to_vec_convective_term_for_restart(i);
+        copy_to_vec_convective_term_for_restart(i);
         vectors_velocity.push_back(&vec_convective_term_for_restart[i]);
       }
     }

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf.h
@@ -62,6 +62,12 @@ public:
   {
   }
 
+  virtual unsigned int
+  get_size_velocity() const;
+
+  virtual unsigned int
+  get_size_pressure() const;
+
   virtual VectorType const &
   get_velocity() const = 0;
 
@@ -111,6 +117,12 @@ protected:
   void
   setup_derived() override;
 
+  virtual void
+  copy_to_vec_convective_term_for_restart(unsigned int const i) const;
+
+  virtual void
+  copy_from_vec_convective_term_for_restart(unsigned int const i);
+
   void
   read_restart_vectors() final;
 
@@ -144,9 +156,10 @@ protected:
   std::shared_ptr<SpatialOperatorBase<dim, Number>> operator_base;
 
   // convective term formulated explicitly
-  bool                    needs_vector_convective_term;
-  std::vector<VectorType> vec_convective_term;
-  VectorType              convective_term_np;
+  bool                            needs_vector_convective_term;
+  std::vector<VectorType>         vec_convective_term;
+  mutable std::vector<VectorType> vec_convective_term_for_restart;
+  VectorType                      convective_term_np;
 
   // required for strongly-coupled partitioned iteration
   bool use_extrapolation;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
@@ -111,11 +111,11 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::get_vectors_serialization(
   std::vector<VectorType const *> & vectors_velocity,
   std::vector<VectorType const *> & vectors_pressure) const
 {
-  vectors_velocity.push_back(&velocity_np); // not needed ##+
+  // vectors_velocity.push_back(&velocity_np); // not needed ##+
   // velocity_red
   // velocity_matvec
 
-  vectors_pressure.push_back(&pressure_np); // not needed ##+
+  // vectors_pressure.push_back(&pressure_np); // not needed ##+
   // pressure
   // pressure_matvec
   // convective_divergence_rhs
@@ -131,11 +131,11 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::set_vectors_deserialization(
   std::vector<VectorType> const & vectors_velocity,
   std::vector<VectorType> const & vectors_pressure)
 {
-  velocity_np = vectors_velocity[0]; // not needed ##+
+  // velocity_np = vectors_velocity[0]; // not needed ##+
   // velocity_red
   // velocity_matvec
 
-  pressure_np = vectors_pressure[0]; // not needed ##+
+  // pressure_np = vectors_pressure[0]; // not needed ##+
   // pressure
   // pressure_matvec
   // convective_divergence_rhs
@@ -449,6 +449,11 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::get_velocity(unsigned int i)
 
   // We need to copy since the vector sizes are different.
   op_rt->copy_this_to_mf_vector(velocity[i], velocity_for_restart[i]);
+
+  // Distibute the constraints to check the output visually. Note that the constraints are constant
+  // in time.
+  pde_operator->get_constraint_u().distribute(velocity_for_restart[i]);
+
   return velocity_for_restart[i];
 }
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
@@ -112,6 +112,8 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::get_vectors_serialization(
   // The reordering is accounted for in
   // `IncNS::SpatialOperatorBase::serialize_vectors()`.
 
+  vectors_velocity.push_back(&velocity_np);
+
   // `velocity_red` needs to be converted to standard matrix-free vector
   for(unsigned int i = 0; i < velocity_red_for_restart.size(); ++i)
   {
@@ -129,6 +131,8 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::get_vectors_serialization(
 
     vectors_velocity.push_back(&velocity_matvec_for_restart[i]);
   }
+
+  vectors_pressure.push_back(&pressure_np);
 
   // `pressure_matvec` data type needs to be converted
   for(unsigned int i = 0; i < pressure_matvec_for_restart.size(); ++i)
@@ -161,23 +165,29 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::set_vectors_deserialization(
   // The reordering is accounted for in
   // `IncNS::SpatialOperatorBase::serialize_vectors()`.
 
+  velocity_np = vectors_velocity[0];
+
   // `velocity_red` needs to be converted from standard matrix-free vector
+  unsigned int idx_velocity = 1;
   for(unsigned int i = 0; i < velocity_red.size(); ++i)
   {
     // copy entries converting Number to float
-    op_rt_float->copy_mf_to_this_vector(vectors_velocity[i], velocity_red[i]);
+    op_rt_float->copy_mf_to_this_vector(vectors_velocity[idx_velocity], velocity_red[i]);
+    idx_velocity += 1;
   }
 
   // `velocity_matvec` needs to be converted from standard matrix-free vector
   for(unsigned int i = 0; i < velocity_matvec.size(); ++i)
   {
     // copy entries converting Number to float
-    op_rt_float->copy_mf_to_this_vector(vectors_velocity[velocity_red.size() + i],
-                                        velocity_matvec[i]);
+    op_rt_float->copy_mf_to_this_vector(vectors_velocity[idx_velocity], velocity_matvec[i]);
+    idx_velocity += 1;
   }
 
+  pressure_np = vectors_pressure[0];
+
   // `pressure_matvec` data type needs to be conerted
-  unsigned int idx_pressure = 0;
+  unsigned int idx_pressure = 1;
   for(unsigned int i = 0; i < pressure_matvec.size(); ++i)
   {
     // copy entries converting Number to float

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.h
@@ -179,12 +179,12 @@ private:
 
   std::vector<VectorType> velocity; // `op_rt` vector
 
-  VectorType velocity_np; // mf vector, do not serialize
+  VectorType velocity_np; // mf vector
 
   std::vector<VectorTypeFloat> velocity_red;    // `op_rt_float` vector
   std::vector<VectorTypeFloat> velocity_matvec; // `op_rt_float` vector
 
-  VectorType pressure_np;  // mf vector, do not serialize
+  VectorType pressure_np;  // mf vector
   VectorType pressure_rhs; // mf vector, do not serialize
 
   std::vector<VectorTypeFloat> pressure;                  // `dg_matrix` vector

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.h
@@ -177,18 +177,18 @@ private:
 
   std::shared_ptr<Operator> pde_operator;
 
-  std::vector<VectorType> velocity; // op_rt vector
+  std::vector<VectorType> velocity; // `op_rt` vector
 
-  VectorType velocity_np; // mf vector, do not serialize ##+
+  VectorType velocity_np; // mf vector, do not serialize
 
-  std::vector<VectorTypeFloat> velocity_red;    // op_rt_float vector
-  std::vector<VectorTypeFloat> velocity_matvec; // op_rt_float vector
+  std::vector<VectorTypeFloat> velocity_red;    // `op_rt_float` vector
+  std::vector<VectorTypeFloat> velocity_matvec; // `op_rt_float` vector
 
-  VectorType pressure_np;  // mf vector, do not serialize ##+
-  VectorType pressure_rhs; // mf vector, do not serialize ##+
+  VectorType pressure_np;  // mf vector, do not serialize
+  VectorType pressure_rhs; // mf vector, do not serialize
 
-  std::vector<VectorTypeFloat> pressure;                  // dg_matrix vector
-  std::vector<VectorTypeFloat> pressure_matvec;           // dg_matrix vector
+  std::vector<VectorTypeFloat> pressure;                  // `dg_matrix` vector
+  std::vector<VectorTypeFloat> pressure_matvec;           // `dg_matrix` vector
   std::vector<VectorType>      convective_divergence_rhs; // mf vector
   std::vector<VectorType>      divergences;               // mf vector
   std::vector<VectorType>      pressure_nbc_rhs;          // mf vector
@@ -199,11 +199,8 @@ private:
   mutable std::vector<VectorType> velocity_red_for_restart;    // mf vector
   mutable std::vector<VectorType> velocity_matvec_for_restart; // mf vector
 
-  mutable std::vector<VectorType> pressure_for_restart;                  // mf vector
-  mutable std::vector<VectorType> pressure_matvec_for_restart;           // mf vector
-  mutable std::vector<VectorType> convective_divergence_rhs_for_restart; // mf vector
-  mutable std::vector<VectorType> divergences_for_restart;               // mf vector
-  mutable std::vector<VectorType> pressure_nbc_rhs_for_restart;          // mf vector
+  mutable std::vector<VectorType> pressure_for_restart;        // mf vector
+  mutable std::vector<VectorType> pressure_matvec_for_restart; // mf vector
 
   // required for strongly-coupled partitioned FSI
   VectorType pressure_last_iter;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.h
@@ -105,6 +105,21 @@ private:
   setup_derived() final;
 
   void
+  write_vector_norms() const;
+
+  unsigned int
+  get_size_velocity() const final;
+
+  unsigned int
+  get_size_pressure() const final;
+
+  void
+  copy_to_vec_convective_term_for_restart(unsigned int const i) const final;
+
+  void
+  copy_from_vec_convective_term_for_restart(unsigned int const i) final;
+
+  void
   get_vectors_serialization(std::vector<VectorType const *> & vectors_velocity,
                             std::vector<VectorType const *> & vectors_pressure) const final;
 
@@ -162,21 +177,33 @@ private:
 
   std::shared_ptr<Operator> pde_operator;
 
-  std::vector<VectorType> velocity;
+  std::vector<VectorType> velocity; // op_rt vector
 
-  VectorType velocity_np;
+  VectorType velocity_np; // mf vector, do not serialize ##+
 
-  std::vector<VectorTypeFloat> velocity_red;
-  std::vector<VectorTypeFloat> velocity_matvec;
+  std::vector<VectorTypeFloat> velocity_red;    // op_rt_float vector
+  std::vector<VectorTypeFloat> velocity_matvec; // op_rt_float vector
 
-  VectorType pressure_np;
-  VectorType pressure_rhs;
+  VectorType pressure_np;  // mf vector, do not serialize ##+
+  VectorType pressure_rhs; // mf vector, do not serialize ##+
 
-  std::vector<VectorTypeFloat> pressure;
-  std::vector<VectorTypeFloat> pressure_matvec;
-  std::vector<VectorType>      convective_divergence_rhs;
-  std::vector<VectorType>      divergences;
-  std::vector<VectorType>      pressure_nbc_rhs;
+  std::vector<VectorTypeFloat> pressure;                  // dg_matrix vector
+  std::vector<VectorTypeFloat> pressure_matvec;           // dg_matrix vector
+  std::vector<VectorType>      convective_divergence_rhs; // mf vector
+  std::vector<VectorType>      divergences;               // mf vector
+  std::vector<VectorType>      pressure_nbc_rhs;          // mf vector
+
+  // vectors required for restart, all standard matrix-free vectors, but might feature DoF
+  // reordering compared to the default one.
+  mutable std::vector<VectorType> velocity_for_restart;        // mf vector
+  mutable std::vector<VectorType> velocity_red_for_restart;    // mf vector
+  mutable std::vector<VectorType> velocity_matvec_for_restart; // mf vector
+
+  mutable std::vector<VectorType> pressure_for_restart;                  // mf vector
+  mutable std::vector<VectorType> pressure_matvec_for_restart;           // mf vector
+  mutable std::vector<VectorType> convective_divergence_rhs_for_restart; // mf vector
+  mutable std::vector<VectorType> divergences_for_restart;               // mf vector
+  mutable std::vector<VectorType> pressure_nbc_rhs_for_restart;          // mf vector
 
   // required for strongly-coupled partitioned FSI
   VectorType pressure_last_iter;

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -87,9 +87,9 @@ template<typename VectorType>
 inline void
 print_vector_l2_norm(VectorType const & vector)
 {
-  MPI_Comm const & mpi_comm = vector.get_mpi_communicator();
-  double const     l2_norm  = vector.l2_norm();
-  if(dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0)
+  double const l2_norm = vector.l2_norm();
+  // Using `MPI_COMM_WORLD` as we might run on a sub-communicator with joined MPI processes.
+  if(dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
   {
     std::cout << "    vector global l2 norm: " << std::scientific << std::setprecision(8)
               << std::setw(20) << l2_norm << "\n";


### PR DESCRIPTION
This is the fix for the restart capabilities for `BDFConsistenSplittingExtruded`.
We assume that we only use `SpatialDiscretization::HDIV`.

One can change core counts, polynomial degree and spatial resolution.

The mapping is a bit flimsy for coarse resolutions. it might be good to fix the spatial resolution and `mapping_degree`, but that should be much better with finer grids.

How to use:
take the two input files and set `read_restart` or `write_restart` accordingly.
Run first with `TriangulationType::Serial` on _any_ hp resolution to store the coarse grid.
Then run the case to create the restart data.
Then run the case from restart.

Below results for a test case with low Reynolds number = smooth solution:
---------------------------------
IDENTICAL DISCRETIZATION:
vector norms seem to be alright, but the ones where I have to do a type conversion and a projection _twice_ have larger errors:
<img width="748" height="549" alt="image" src="https://github.com/user-attachments/assets/797799a3-3013-47fd-b73b-9a76fc1b1c3b" />
the next timestep after de-/serialization should give identical iteration counts since the grid is identical, but this is not the case:
<img width="2114" height="832" alt="image" src="https://github.com/user-attachments/assets/f4a5f0e7-8543-4097-bcfc-00758af89eaa" />
even though I copy all the vectors to get a good initial guess ... but those are the ones affected by the double projection and type conversion. Also, the time step size is recomputed at startup.
---------------------------------
NONMATCHING DISCRETIZATION:
(vector norms are different, but that is to be expected as the DoF count is different)
iteration counts are also different, but in addition to the error introduced by deserialization we see different iteration counts since 
<img width="2114" height="832" alt="image" src="https://github.com/user-attachments/assets/dc1294a8-5a5c-42c7-a88a-db24d5e9f64d" />
