### PR TITLE
enable printing in `FlowRateController`

### DIFF
--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -88,23 +88,25 @@ public:
   void
   write_restart_data(boost::archive::binary_oarchive & archive) const override
   {
-    const auto parameters = flow_rate_controller.get_parameters_for_serialization();
-    archive &  parameters;
+    const auto parameters =
+      flow_rate_controller.get_parameters_for_serialization(true /* print_parameters */);
+    archive & parameters;
   }
 
   // The information is always read on rank zero and then broadcast to all
-  // ranks by the additional function synchronize_function_parameters()
+  // ranks by the additional function `broadcast_function_parameters()`
   void
   read_restart_data(boost::archive::binary_iarchive & archive) override
   {
     // get right data type for parameters by getting (at this point invalid)
     // data from the controller...
-    auto parameters = flow_rate_controller.get_parameters_for_serialization();
+    auto parameters =
+      flow_rate_controller.get_parameters_for_serialization(false /* print_parameters */);
 
     // ... and now set the actual parameter as read from the file
     archive & parameters;
     const_cast<FlowRateController &>(flow_rate_controller)
-      .set_parameters_from_serialization(parameters);
+      .set_parameters_from_serialization(parameters, true /* print_parameters */);
   }
 
   void
@@ -113,7 +115,7 @@ public:
     auto parameters = flow_rate_controller.get_parameters_for_serialization();
     parameters      = dealii::Utilities::MPI::broadcast(comm, parameters, rank);
     const_cast<FlowRateController &>(flow_rate_controller)
-      .set_parameters_from_serialization(parameters);
+      .set_parameters_from_serialization(parameters, false /* print_parameters */);
   }
 
 private:
@@ -204,7 +206,11 @@ private:
 
     // finally refresh the flow rate controller
     flow_rate_controller.reset(
-      new FlowRateController(bulk_velocity, target_flow_rate, H, start_time));
+      new FlowRateController(bulk_velocity,
+                             target_flow_rate,
+                             H,
+                             start_time,
+                             true /* assert_non_matching_parameters_at_restart */));
   }
 
   void
@@ -815,7 +821,7 @@ private:
   // restart
   bool   write_restart         = false;
   bool   read_restart          = false;
-  double restart_interval_time = (end_time - start_time) * 0.8;
+  double restart_interval_time = 8.0 * flow_through_time;
 
   // sampling
   bool         calculate_statistics        = true;

--- a/applications/incompressible_navier_stokes/periodic_hill/include/flow_rate_controller.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/include/flow_rate_controller.h
@@ -32,7 +32,8 @@ public:
   FlowRateController(double const bulk_velocity,
                      double const target_flow_rate,
                      double const H,
-                     double const start_time)
+                     double const start_time,
+                     bool const   assert_non_matching_parameters_at_restart = false)
     : bulk_velocity(bulk_velocity),
       target_flow_rate(target_flow_rate),
       length_scale(H),
@@ -40,7 +41,8 @@ public:
       f_damping(0.0),
       time_old(start_time),
       flow_rate(0.0),
-      flow_rate_old(0.0)
+      flow_rate_old(0.0),
+      assert_non_matching_parameters_at_restart(assert_non_matching_parameters_at_restart)
   {
   }
 
@@ -76,24 +78,86 @@ public:
     time_old      = time;
   }
 
-  std::array<double, 5>
-  get_parameters_for_serialization() const
+  std::array<double, 8>
+  get_parameters_for_serialization(bool const print_parameters = false) const
   {
-    std::array<double, 5> parameters{{f, f_damping, time_old, flow_rate, flow_rate_old}};
+    // Store complete state of the `FlowRateController`.
+    std::array<double, 8> parameters{{f,
+                                      f_damping,
+                                      time_old,
+                                      flow_rate,
+                                      flow_rate_old,
+                                      bulk_velocity,
+                                      target_flow_rate,
+                                      length_scale}};
+
+    if(print_parameters)
+    {
+      print_parameters_for_all_ranks();
+    }
+
     return parameters;
   }
 
   void
-  set_parameters_from_serialization(const std::array<double, 5> & parameters)
+  set_parameters_from_serialization(const std::array<double, 8> & parameters,
+                                    bool const                    print_parameters = false)
   {
     f             = parameters[0];
     f_damping     = parameters[1];
     time_old      = parameters[2];
     flow_rate     = parameters[3];
     flow_rate_old = parameters[4];
+
+    // Check if the serialized data matches with the given parameters.
+    if(assert_non_matching_parameters_at_restart)
+    {
+      const double bulk_velocity_old    = parameters[5];
+      const double target_flow_rate_old = parameters[6];
+      const double length_scale_old     = parameters[7];
+
+      AssertThrow(std::abs(bulk_velocity_old - bulk_velocity) < 1e-20,
+                  dealii::ExcMessage("The `bulk_velocity` parameter provided at restart "
+                                     "does not match the value serialized"));
+      AssertThrow(std::abs(target_flow_rate_old - target_flow_rate) < 1e-20,
+                  dealii::ExcMessage("The `bulk_velocity` parameter provided at restart "
+                                     "does not match the value serialized"));
+      AssertThrow(std::abs(length_scale_old - length_scale) < 1e-20,
+                  dealii::ExcMessage("The `bulk_velocity` parameter provided at restart "
+                                     "does not match the value serialized"));
+    }
+
+    if(print_parameters)
+    {
+      print_parameters_for_all_ranks();
+    }
   }
 
 private:
+  void
+  print_parameters_for_all_ranks() const
+  {
+    unsigned int const mpi_process = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+    for(unsigned int i = 0; i < dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD); ++i)
+    {
+      if(i == mpi_process)
+      {
+        // clang-format off
+        std::cout << "    FlowRateController parameters: (MPI process "
+                  << std::to_string(mpi_process) << ")\n" << std::scientific << std::setprecision(4)
+                  << "      f                = " << f << "\n"
+                  << "      f_damping        = " << f_damping << "\n"
+                  << "      time_old         = " << time_old << "\n"
+                  << "      flow_rate        = " << flow_rate << "\n"
+                  << "      flow_rate_old    = " << flow_rate_old << "\n"
+                  << "      bulk_velocity    = " << bulk_velocity << "\n"
+                  << "      target_flow_rate = " << target_flow_rate << "\n"
+                  << "      length_scale     = " << length_scale << "\n";
+        // clang-format on
+      }
+    }
+  }
+
   double const bulk_velocity, target_flow_rate, length_scale;
 
   double f;
@@ -103,6 +167,8 @@ private:
 
   double flow_rate;
   double flow_rate_old;
+
+  bool const assert_non_matching_parameters_at_restart;
 };
 
 } // namespace IncNS

--- a/applications/incompressible_navier_stokes/periodic_hill/input.json
+++ b/applications/incompressible_navier_stokes/periodic_hill/input.json
@@ -18,6 +18,7 @@
         "TriangulationType": "Distributed",
         "ReadRestart": "false",
         "WriteRestart": "false",
+        "RestartIntervalTime": "0.8",
         "TemporalDiscretization": "BDFDualSplittingExtruded",
         "SpatialDiscretization": "HDIV",
         "Inviscid": "false",

--- a/applications/incompressible_navier_stokes/periodic_hill/input_reference.json
+++ b/applications/incompressible_navier_stokes/periodic_hill/input_reference.json
@@ -18,6 +18,7 @@
         "TriangulationType": "Serial",
         "ReadRestart": "false",
         "WriteRestart": "true",
+        "RestartIntervalTime": "0.8",
         "TemporalDiscretization": "BDFConsistentSplittingExtruded",
         "SpatialDiscretization": "HDIV",
         "Inviscid": "false",

--- a/applications/incompressible_navier_stokes/periodic_hill/input_restart.json
+++ b/applications/incompressible_navier_stokes/periodic_hill/input_restart.json
@@ -18,6 +18,7 @@
         "TriangulationType": "Distributed",
         "ReadRestart": "true",
         "WriteRestart": "false",
+        "RestartIntervalTime": "0.8",
         "TemporalDiscretization": "BDFConsistentSplittingExtruded",
         "SpatialDiscretization": "HDIV",
         "Inviscid": "false",

--- a/include/exadg/time_integration/restart.h
+++ b/include/exadg/time_integration/restart.h
@@ -219,17 +219,18 @@ write_deserialization_parameters(MPI_Comm const &                       mpi_comm
     boost::archive::binary_oarchive output_archive(stream);
 
     // Sequence has to match `read_deserialization_parameters()`.
-    output_archive &   parameters.degree;
-    output_archive &   parameters.degree_u;
-    output_archive &   parameters.degree_p;
-    output_archive &   parameters.mapping_degree;
-    output_archive &   parameters.consider_mapping_write;
-    output_archive &   parameters.triangulation_type;
-    output_archive &   parameters.spatial_discretization;
+    output_archive & parameters.degree;
+    output_archive & parameters.degree_u;
+    output_archive & parameters.degree_p;
+    output_archive & parameters.mapping_degree;
+    output_archive & parameters.consider_mapping_write;
+    output_archive & parameters.triangulation_type;
+    output_archive & parameters.spatial_discretization;
+
+    // Check if serializable functions were provided and add them.
     const unsigned int n_functions = parameters.serializable_functions.size();
     output_archive &   n_functions;
-
-    for(const std::shared_ptr<SerializableFunction<dim>> function :
+    for(std::shared_ptr<SerializableFunction<dim>> const & function :
         parameters.serializable_functions)
       function->write_restart_data(output_archive);
   }
@@ -269,6 +270,7 @@ read_deserialization_parameters(MPI_Comm const &                 mpi_comm,
     input_archive & parameters.triangulation_type;
     input_archive & parameters.spatial_discretization;
 
+    // Read serializable in case they were added.
     unsigned int    n_functions = 0;
     input_archive & n_functions;
     AssertThrow(parameters.serializable_functions.size() == n_functions,

--- a/include/exadg/utilities/serializable_function.h
+++ b/include/exadg/utilities/serializable_function.h
@@ -40,22 +40,22 @@ public:
   {
   }
 
-  virtual void
-  write_restart_data(boost::archive::binary_oarchive &) const
-  {
-  }
+  /*
+   * These functions define the interface for the added functionality to serialize and deserialize
+   * the parameters of derived classes.
+   */
 
-  // The information is always read on rank zero and then broadcast to all
-  // ranks by the additional function synchronize_function_parameters()
+  // Add data to be serialized to the archive.
   virtual void
-  read_restart_data(boost::archive::binary_iarchive &)
-  {
-  }
+  write_restart_data(boost::archive::binary_oarchive & archive) const = 0;
 
-
+  // Read serialized data from th archive. Note that the information is always read on rank 0 and
+  // then broadcast to all ranks by the additional function `broadcast_function_parameters()`
   virtual void
-  broadcast_function_parameters(const MPI_Comm, const unsigned int = 0)
-  {
-  }
+  read_restart_data(boost::archive::binary_iarchive & archive) = 0;
+
+  // Broadcast the de-/serialized parameters from `root_rank` to all other ranks.
+  virtual void
+  broadcast_function_parameters(const MPI_Comm mpi_comm, const unsigned int root_rank = 0) = 0;
 };
 } // namespace ExaDG


### PR DESCRIPTION
- store _all_ parameters `FlowRateController` (incl. the ones that are set in the respective application)
- add printing functionality to `FlowRateController` to check values at de-/serialization
- optionally assert mismatching parameters, currently activated to make sure we catch if we have "weird increased iterations at restart" in case we change the parameters such that the serialized solution does not fit the target flow rate at restart. 

I also checked that the broadcasting of the parameters is correct.
The testing of the de-/serialization of the `FlowRateCalculator` is complete with this.
Once we setup a `ctest` for restart of `TimeIntBDFConsistentSplittingExtruded`, we can also check that the parameters are correctly de-/serialized.