### PR TITLE
enable restart pojection in undeformed grid

### DIFF
--- a/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
+++ b/applications/acoustic_conservation_equations/circular_moving_gauss_pulse/application.h
@@ -203,6 +203,7 @@ private:
     this->param.restart_data.discretization_identical     = false;
     this->param.restart_data.consider_mapping_write       = true;
     this->param.restart_data.consider_mapping_read_source = true;
+    this->param.restart_data.consider_mapping_read_target = true;
 
     this->param.restart_data.rpe_rtree_level            = 0;
     this->param.restart_data.rpe_tolerance_unit_cell    = 1e-6;

--- a/applications/compressible_navier_stokes/manufactured_solution/application.h
+++ b/applications/compressible_navier_stokes/manufactured_solution/application.h
@@ -418,6 +418,7 @@ private:
     this->param.restart_data.discretization_identical     = false;
     this->param.restart_data.consider_mapping_write       = true;
     this->param.restart_data.consider_mapping_read_source = true;
+    this->param.restart_data.consider_mapping_read_target = true;
 
     this->param.restart_data.rpe_rtree_level            = 0;
     this->param.restart_data.rpe_tolerance_unit_cell    = 1e-6;

--- a/applications/convection_diffusion/rotating_hill/application.h
+++ b/applications/convection_diffusion/rotating_hill/application.h
@@ -162,6 +162,7 @@ private:
     this->param.restart_data.discretization_identical     = false;
     this->param.restart_data.consider_mapping_write       = true;
     this->param.restart_data.consider_mapping_read_source = true;
+    this->param.restart_data.consider_mapping_read_target = true;
 
     this->param.restart_data.rpe_rtree_level            = 0;
     this->param.restart_data.rpe_tolerance_unit_cell    = 1e-2;

--- a/applications/convection_diffusion/sine_wave/application.h
+++ b/applications/convection_diffusion/sine_wave/application.h
@@ -142,6 +142,7 @@ private:
     this->param.restart_data.discretization_identical     = false;
     this->param.restart_data.consider_mapping_write       = true;
     this->param.restart_data.consider_mapping_read_source = true;
+    this->param.restart_data.consider_mapping_read_target = true;
 
     this->param.restart_data.rpe_rtree_level            = 0;
     this->param.restart_data.rpe_tolerance_unit_cell    = 1e-6;

--- a/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
+++ b/applications/incompressible_navier_stokes/navier_stokes_manufactured/application.h
@@ -487,6 +487,7 @@ private:
     this->param.restart_data.discretization_identical                        = false;
     this->param.restart_data.consider_mapping_write                          = move_grid;
     this->param.restart_data.consider_mapping_read_source                    = move_grid;
+    this->param.restart_data.consider_mapping_read_target                    = move_grid;
     this->param.restart_data.consider_restart_time_in_mesh_movement_function = true;
 
     this->param.restart_data.rpe_rtree_level            = 0;

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -302,8 +302,9 @@ private:
 
     // Same `mapping_degree` and spatial resolution are the most stable options for restart,
     // polynomial degree can be varied.
-    this->param.restart_data.consider_mapping_write                          = true;
-    this->param.restart_data.consider_mapping_read_source                    = true;
+    this->param.restart_data.consider_mapping_write                          = false;
+    this->param.restart_data.consider_mapping_read_source                    = false;
+    this->param.restart_data.consider_mapping_read_target                    = false;
     this->param.restart_data.consider_restart_time_in_mesh_movement_function = true;
 
     this->param.restart_data.rpe_rtree_level            = 3;

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -127,6 +127,13 @@ SpatialOperator<dim, Number>::setup()
              mf_data->get_quadrature_vector(),
              mf_data->data);
 
+  if(param.restart_data.requires_mapping_reset(param.restarted_simulation))
+  {
+    // We need to adapt the mapping of the `MatrixFree` object for ALE formulations and when
+    // performing restart projections on undeformed grids.
+    matrix_free_mutable = mf;
+  }
+
   // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
   // arguments.
   this->setup(mf, mf_data);
@@ -387,6 +394,28 @@ SpatialOperator<dim, Number>::deserialize_vectors(
       checkpoint_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
     }
 
+    // Reset the mapping in `MatrixFree` to project on the undeformed configuration.
+    if(param.restart_data.requires_mapping_reset())
+    {
+      // Attaching manifolds, we assume that we at least refine once. We do not support coarsening
+      // (undoing the refinement without the manifold) and subsequent refinement.
+      dealii::Triangulation<dim> const & triangulation =
+        matrix_free->get_dof_handler().get_triangulation();
+      std::vector<dealii::types::manifold_id> manifold_ids = triangulation.get_manifold_ids();
+      AssertThrow(manifold_ids.size() == 1 and manifold_ids[0] == dealii::numbers::flat_manifold_id,
+                  dealii::ExcMessage("Combination of manifolds and grid-to-grid projection "
+                                     "in unmapped grid at restart not supported."));
+
+      // Create dummy linear mapping since we have no mapping serialized to restore.
+      std::shared_ptr<dealii::Mapping<dim>> default_mapping;
+      GridUtilities::create_mapping(default_mapping,
+                                    get_element_type(triangulation),
+                                    1 /* mapping_degree */);
+
+      // Update `MatrixFree` mapping, needs to be restored after grid-to-grid projection.
+      matrix_free_mutable->update_mapping(*default_mapping);
+    }
+
     ExaDG::GridToGridProjection::GridToGridProjectionData<dim> data;
     data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
     data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
@@ -400,6 +429,12 @@ SpatialOperator<dim, Number>::deserialize_vectors(
       *matrix_free,
       vectors_per_dof_handler,
       data);
+
+    if(param.restart_data.requires_mapping_reset())
+    {
+      // Restore the mapping in `MatrixFree` to continue with the requested mapping after restart.
+      matrix_free_mutable->update_mapping(*this->get_mapping());
+    }
   }
 
   // Recover ghost vector state.
@@ -553,8 +588,7 @@ SpatialOperator<dim, Number>::initialize_dof_handler_and_constraints()
   dof_handler_u.distribute_dofs(*fe_u);
 
   // de-/serialization of mapping requires DoFHandler
-  if((param.restart_data.consider_mapping_write and param.restart_data.write_restart) or
-     (param.restart_data.consider_mapping_read_source and param.restarted_simulation))
+  if(param.restart_data.requires_dof_handler_mapping(param.restarted_simulation))
   {
     fe_mapping =
       create_finite_element<dim>(param.grid.element_type, true, dim, param.mapping_degree);

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.h
@@ -266,6 +266,12 @@ private:
   std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data;
   std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free;
 
+  // If we want to be able to update the mapping, we need a pointer to a non-const `MatrixFree`
+  // object. `matrix_free_mutable` points to the same object the pointer to a const `MatrixFree`
+  // object `matrix_free` is pointing to. This variable is needed for ALE formulations or for
+  // grid-to-grid projections on an undeformed grid.
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free_mutable;
+
   /*
    * Basic operators.
    */

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -78,8 +78,7 @@ Operator<dim, Number>::initialize_dof_handler_and_constraints()
   dof_handler_vector.distribute_dofs(*fe_vector);
   dof_handler_scalar.distribute_dofs(*fe_scalar);
 
-  if((param.restart_data.consider_mapping_write and param.restart_data.write_restart) or
-     (param.restart_data.consider_mapping_read_source and param.restarted_simulation))
+  if(param.restart_data.requires_dof_handler_mapping(param.restarted_simulation))
   {
     fe_mapping =
       create_finite_element<dim>(ElementType::Hypercube, true, dim, param.mapping_degree);
@@ -281,6 +280,13 @@ Operator<dim, Number>::setup()
              mf_data->get_quadrature_vector(),
              mf_data->data);
 
+  if(param.restart_data.requires_mapping_reset(param.restarted_simulation))
+  {
+    // We need to adapt the mapping of the `MatrixFree` object for ALE formulations and when
+    // performing restart projections on undeformed grids.
+    matrix_free_mutable = mf;
+  }
+
   // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
   // arguments.
   this->setup(mf, mf_data);
@@ -460,6 +466,28 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
       checkpoint_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
     }
 
+    // Reset the mapping in `MatrixFree` to project on the undeformed configuration.
+    if(param.restart_data.requires_mapping_reset())
+    {
+      // Attaching manifolds, we assume that we at least refine once. We do not support coarsening
+      // (undoing the refinement without the manifold) and subsequent refinement.
+      dealii::Triangulation<dim> const & triangulation =
+        matrix_free->get_dof_handler().get_triangulation();
+      std::vector<dealii::types::manifold_id> manifold_ids = triangulation.get_manifold_ids();
+      AssertThrow(manifold_ids.size() == 1 and manifold_ids[0] == dealii::numbers::flat_manifold_id,
+                  dealii::ExcMessage("Combination of manifolds and grid-to-grid projection "
+                                     "in unmapped grid at restart not supported."));
+
+      // Create dummy linear mapping since we have no mapping serialized to restore.
+      std::shared_ptr<dealii::Mapping<dim>> default_mapping;
+      GridUtilities::create_mapping(default_mapping,
+                                    get_element_type(triangulation),
+                                    1 /* mapping_degree */);
+
+      // Update `MatrixFree` mapping, needs to be restored after grid-to-grid projection.
+      matrix_free_mutable->update_mapping(*default_mapping);
+    }
+
     ExaDG::GridToGridProjection::GridToGridProjectionData<dim> data;
     data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
     data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
@@ -473,6 +501,12 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
       *matrix_free,
       vectors_per_dof_handler,
       data);
+
+    if(param.restart_data.requires_mapping_reset())
+    {
+      // Restore the mapping in `MatrixFree` to continue with the requested mapping after restart.
+      matrix_free_mutable->update_mapping(this->get_mapping());
+    }
   }
 
   // Recover ghost vector state.

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.h
@@ -269,6 +269,12 @@ private:
   std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data;
   std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free;
 
+  // If we want to be able to update the mapping, we need a pointer to a non-const `MatrixFree`
+  // object. `matrix_free_mutable` points to the same object the pointer to a const `MatrixFree`
+  // object `matrix_free` is pointing to. This variable is needed for ALE formulations or for
+  // grid-to-grid projections on an undeformed grid.
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free_mutable;
+
   /*
    * Basic operators.
    */

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -74,7 +74,7 @@ Operator<dim, Number>::Operator(
     dof_handler_velocity = std::make_shared<dealii::DoFHandler<dim>>(*grid->triangulation);
   }
 
-  if(needs_dof_handler_mapping())
+  if(param.restart_data.requires_dof_handler_mapping(param.restarted_simulation))
   {
     fe_mapping =
       create_finite_element<dim>(ElementType::Hypercube, true, dim, param.mapping_degree);
@@ -105,7 +105,7 @@ Operator<dim, Number>::initialize_dof_handler_and_constraints()
     dof_handler_velocity->distribute_dofs(*fe_velocity);
   }
 
-  if(needs_dof_handler_mapping())
+  if(param.restart_data.requires_dof_handler_mapping(param.restarted_simulation))
   {
     dof_handler_mapping->distribute_dofs(*fe_mapping);
   }
@@ -356,8 +356,12 @@ Operator<dim, Number>::do_setup()
              mf_data->get_quadrature_vector(),
              mf_data->data);
 
-  if(param.ale_formulation)
-    matrix_free_own_storage = mf;
+  if(param.ale_formulation or param.restart_data.requires_mapping_reset(param.restarted_simulation))
+  {
+    // We need to adapt the mapping of the `MatrixFree` object for ALE formulations and when
+    // performing restart projections on undeformed grids.
+    matrix_free_mutable = mf;
+  }
 
   // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
   // arguments.
@@ -689,6 +693,28 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
       checkpoint_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
     }
 
+    // Reset the mapping in `MatrixFree` to project on the undeformed configuration.
+    if(param.restart_data.requires_mapping_reset())
+    {
+      // Attaching manifolds, we assume that we at least refine once. We do not support coarsening
+      // (undoing the refinement without the manifold) and subsequent refinement.
+      dealii::Triangulation<dim> const & triangulation =
+        matrix_free->get_dof_handler().get_triangulation();
+      std::vector<dealii::types::manifold_id> manifold_ids = triangulation.get_manifold_ids();
+      AssertThrow(manifold_ids.size() == 1 and manifold_ids[0] == dealii::numbers::flat_manifold_id,
+                  dealii::ExcMessage("Combination of manifolds and grid-to-grid projection "
+                                     "in unmapped grid at restart not supported."));
+
+      // Create dummy linear mapping since we have no mapping serialized to restore.
+      std::shared_ptr<dealii::Mapping<dim>> default_mapping;
+      GridUtilities::create_mapping(default_mapping,
+                                    get_element_type(triangulation),
+                                    1 /* mapping_degree */);
+
+      // Update `MatrixFree` mapping, needs to be restored after grid-to-grid projection.
+      matrix_free_mutable->update_mapping(*default_mapping);
+    }
+
     ExaDG::GridToGridProjection::GridToGridProjectionData<dim> data;
     data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
     data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
@@ -702,6 +728,12 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
       *matrix_free,
       vectors_per_dof_handler,
       data);
+
+    if(param.restart_data.requires_mapping_reset())
+    {
+      // Restore the mapping in `MatrixFree` to continue with the requested mapping after restart.
+      matrix_free_mutable->update_mapping(*this->get_mapping());
+    }
   }
 
   // Recover ghost vector state.
@@ -908,11 +940,10 @@ Operator<dim, Number>::update_after_grid_motion(bool const update_matrix_free)
 {
   if(update_matrix_free)
   {
-    // Since matrix_free points to matrix_free_own_storage, we also update the actual/main
-    // MatrixFree object called matrix_free.
-    matrix_free_own_storage->update_mapping(*get_mapping());
+    // Since matrix_free points to `matrix_free_mutable`, we also update the actual/main
+    // MatrixFree object called `matrix_free`.
+    matrix_free_mutable->update_mapping(*get_mapping());
   }
-
 
   // update SIPG penalty parameter of diffusive operator which depends on the deformation
   // of elements
@@ -1113,14 +1144,6 @@ bool
 Operator<dim, Number>::needs_own_dof_handler_velocity() const
 {
   return param.analytical_velocity_field and param.store_analytical_velocity_in_dof_vector;
-}
-
-template<int dim, typename Number>
-bool
-Operator<dim, Number>::needs_dof_handler_mapping() const
-{
-  return ((param.restart_data.consider_mapping_write and param.restart_data.write_restart) or
-          (param.restart_data.consider_mapping_read_source and param.restarted_simulation));
 }
 
 template<int dim, typename Number>

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.h
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.h
@@ -331,9 +331,6 @@ private:
   bool
   needs_own_dof_handler_velocity() const;
 
-  bool
-  needs_dof_handler_mapping() const;
-
   std::string
   get_quad_name() const;
 
@@ -431,10 +428,11 @@ private:
   std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free;
   std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data;
 
-  // If we want to be able to update the mapping, we need a pointer to a non-const MatrixFree
-  // object. In case this object is created, we let the above object called matrix_free point to
-  // matrix_free_own_storage. This variable is needed for ALE formulations.
-  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free_own_storage;
+  // If we want to be able to update the mapping, we need a pointer to a non-const `MatrixFree`
+  // object. `matrix_free_mutable` points to the same object the pointer to a const `MatrixFree`
+  // object `matrix_free` is pointing to. This variable is needed for ALE formulations or for
+  // grid-to-grid projections on an undeformed grid.
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free_mutable;
 
   /*
    * Basic operators.

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -201,8 +201,7 @@ SpatialOperatorBase<dim, Number>::initialize_dof_handler_and_constraints()
 
   fe_u = setup_fe_u(param.spatial_discretization, param.grid.element_type, param.degree_u);
 
-  if((param.restart_data.consider_mapping_write and param.restart_data.write_restart) or
-     (param.restart_data.consider_mapping_read_source and param.restarted_simulation))
+  if(param.restart_data.requires_dof_handler_mapping(param.restarted_simulation))
   {
     fe_mapping          = create_finite_element<dim>(param.grid.element_type,
                                             true /* is_dg */,
@@ -799,8 +798,12 @@ SpatialOperatorBase<dim, Number>::setup()
              mf_data->get_quadrature_vector(),
              mf_data->data);
 
-  if(param.ale_formulation)
-    matrix_free_own_storage = mf;
+  if(param.ale_formulation or param.restart_data.requires_mapping_reset(param.restarted_simulation))
+  {
+    // We need to adapt the mapping of the `MatrixFree` object for ALE formulations and when
+    // performing restart projections on undeformed grids.
+    matrix_free_mutable = mf;
+  }
 
   // Subsequently, call the other setup function with MatrixFree/MatrixFreeData objects as
   // arguments.
@@ -1316,6 +1319,28 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
       checkpoint_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
     }
 
+    // Reset the mapping in `MatrixFree` to project on the undeformed configuration.
+    if(param.restart_data.requires_mapping_reset())
+    {
+      // Attaching manifolds, we assume that we at least refine once. We do not support coarsening
+      // (undoing the refinement without the manifold) and subsequent refinement.
+      dealii::Triangulation<dim> const & triangulation =
+        matrix_free->get_dof_handler().get_triangulation();
+      std::vector<dealii::types::manifold_id> manifold_ids = triangulation.get_manifold_ids();
+      AssertThrow(manifold_ids.size() == 1 and manifold_ids[0] == dealii::numbers::flat_manifold_id,
+                  dealii::ExcMessage("Combination of manifolds and grid-to-grid projection "
+                                     "in unmapped grid at restart not supported."));
+
+      // Create dummy linear mapping since we have no mapping serialized to restore.
+      std::shared_ptr<dealii::Mapping<dim>> default_mapping;
+      GridUtilities::create_mapping(default_mapping,
+                                    get_element_type(triangulation),
+                                    1 /* mapping_degree */);
+
+      // Update `MatrixFree` mapping, needs to be restored after grid-to-grid projection.
+      matrix_free_mutable->update_mapping(*default_mapping);
+    }
+
     ExaDG::GridToGridProjection::GridToGridProjectionData<dim> data;
     data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
     data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
@@ -1329,6 +1354,12 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
       *matrix_free,
       vectors_per_dof_handler,
       data);
+
+    if(param.restart_data.requires_mapping_reset())
+    {
+      // Restore the mapping in `MatrixFree` to continue with the requested mapping after restart.
+      matrix_free_mutable->update_mapping(*this->get_mapping());
+    }
 
     // `dealii::MatrixFree` does not enforce the periodic constraints on the vector;
     // enforce the constraints for visual comparison purposes.
@@ -1948,9 +1979,9 @@ SpatialOperatorBase<dim, Number>::update_after_grid_motion(bool const update_mat
 {
   if(update_matrix_free)
   {
-    // Since matrix_free points to matrix_free_own_storage, we also update the actual/main
-    // MatrixFree object called matrix_free.
-    matrix_free_own_storage->update_mapping(*get_mapping());
+    // Since matrix_free points to `matrix_free_mutable`, we also update the actual/main
+    // MatrixFree object called `matrix_free`.
+    matrix_free_mutable->update_mapping(*get_mapping());
   }
 
   if(param.turbulence_model_data.is_active)

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -573,10 +573,11 @@ private:
   std::shared_ptr<MatrixFreeData<dim, Number> const>     matrix_free_data;
   std::shared_ptr<dealii::MatrixFree<dim, Number> const> matrix_free;
 
-  // If we want to be able to update the mapping, we need a pointer to a non-const MatrixFree
-  // object. In case this object is created, we let the above object called matrix_free point to
-  // matrix_free_own_storage. This variable is needed for ALE formulations.
-  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free_own_storage;
+  // If we want to be able to update the mapping, we need a pointer to a non-const `MatrixFree`
+  // object. `matrix_free_mutable` points to the same object the pointer to a const `MatrixFree`
+  // object `matrix_free` is pointing to. This variable is needed for ALE formulations or for
+  // grid-to-grid projections on an undeformed grid.
+  std::shared_ptr<dealii::MatrixFree<dim, Number>> matrix_free_mutable;
 
   bool pressure_level_is_undefined;
 

--- a/include/exadg/time_integration/restart_data.h
+++ b/include/exadg/time_integration/restart_data.h
@@ -134,6 +134,7 @@ struct RestartData
       discretization_identical(false),
       consider_mapping_write(false),
       consider_mapping_read_source(false),
+      consider_mapping_read_target(false),
       consider_restart_time_in_mesh_movement_function(true),
       rpe_rtree_level(0),
       rpe_tolerance_unit_cell(1e-12),
@@ -188,6 +189,29 @@ struct RestartData
     return trigger_restart;
   }
 
+  bool
+  requires_dof_handler_mapping(bool const restarted_simulation) const
+  {
+    bool const reading_requires_dof_handler_mapping =
+      restarted_simulation and consider_mapping_read_source;
+    bool const writing_requires_dof_handler_mapping = write_restart and consider_mapping_write;
+
+    return reading_requires_dof_handler_mapping or writing_requires_dof_handler_mapping;
+  }
+
+  bool
+  requires_mapping_reset(bool const restarted_simulation = true) const
+  {
+    if(discretization_identical or not restarted_simulation)
+    {
+      // If we do not restart, we do not need to reset the mapppings. Also, mappings can be safely
+      // ignored if we simply assign the vectors read from snapshot data.
+      return false;
+    }
+
+    return not consider_mapping_read_target;
+  }
+
   bool write_restart;
 
   // Number of snapshots to keep
@@ -236,8 +260,11 @@ struct RestartData
    */
 
   // Reconstruct the mapping for the serialized grid (`source`) in the grid-to-grid projection at
-  // restart. Note that the grid use at restart is always considered as defined in the applciation.
+  // restart. The checkpointed data might carry a mapping, which is used if
+  // `consider_mapping_read_source == true`. The grid used at restart can be considered as defined
+  // in the application or reset to perform the grid-to-grid projection on an unmapped grid.
   bool consider_mapping_read_source;
+  bool consider_mapping_read_target;
 
   // When creating a mapping function via `create_mesh_movement_function()`, use the `start_time` or
   // the `time` serialized to evaluate the mapping at restart.


### PR DESCRIPTION
set 
```
this->param.restart_data.consider_mapping_write              = false;
this->param.restart_data.consider_mapping_read_source = false;
this->param.restart_data.consider_mapping_read_target  = false;
```
and perform the grid-to-grid projection on an undeformed grid.
Very simple change based on `matrix_free_mutable.update_mapping(mapping)`, where we have `matrix_free_mutable` lying around from ALE implemenetations.
I wanted to make sure that the other PDEs are also up-to-date, so I made the changes in all the modules, which support restart.

**testcase**

For our `periodic_hill` testcase, I changed the defaults accordingly.
going from

<img width="267" height="140" alt="image" src="https://github.com/user-attachments/assets/9bacb904-8c04-4f42-a400-1d2a68c7a316" />

to two refinements, one cannot find the points in red shown here:

<img width="686" height="424" alt="image" src="https://github.com/user-attachments/assets/35da42e9-51b1-4f71-b47d-60defb616a73" />

but with grid-to-grid projection on the undeformed blocks, we can restart such a configuration :partying_face: 
The outcome looks as expected in the _eyeball_ norm, we should go for convergence tests and restart tests next.