### PR TITLE
fix warning regarding hidden `vmult()` in OperatorBase

### DIFF
--- a/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/multigrid/multigrid_preconditioner_base.h
@@ -114,6 +114,10 @@ public:
   void
   update() override;
 
+  // Re-expose base overloads to avoid warning related to redefining `vmult()` with different
+  // signatures in based and derived class.
+  using PreconditionerBase<Number>::vmult;
+
   /*
    * This function applies the multigrid preconditioner dst = P^{-1} src.
    */

--- a/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/additive_schwarz_preconditioner.h
@@ -45,6 +45,10 @@ public:
     }
   }
 
+  // Re-expose base overloads to avoid warning related to redefining `vmult()` with different
+  // signatures in based and derived class.
+  using PreconditionerBase<typename Operator::value_type>::vmult;
+
   /*
    *  This function applies the additive Schwarz preconditioner.
    *  Make sure that the additive Schwarz preconditioner has been

--- a/include/exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/block_jacobi_preconditioner.h
@@ -56,6 +56,10 @@ public:
     this->update_needed = false;
   }
 
+  // Re-expose base overloads to avoid warning related to redefining `vmult()` with different
+  // signatures in based and derived class.
+  using PreconditionerBase<typename Operator::value_type>::vmult;
+
   /*
    *  This function applies the block Jacobi preconditioner.
    *  Make sure that the block Jacobi preconditioner has been

--- a/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/inverse_mass_preconditioner.h
@@ -52,6 +52,11 @@ public:
     this->update_needed = false;
   }
 
+
+  // Re-expose base overloads to avoid warning related to redefining `vmult()` with different
+  // signatures in based and derived class.
+  using PreconditionerBase<Number>::vmult;
+
   void
   vmult(VectorType & dst, VectorType const & src) const final
   {

--- a/include/exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/jacobi_preconditioner.h
@@ -47,6 +47,10 @@ public:
     }
   }
 
+  // Re-expose base overloads to avoid warning related to redefining `vmult()` with different
+  // signatures in based and derived class.
+  using PreconditionerBase<typename Operator::value_type>::vmult;
+
   void
   vmult(VectorType & dst, VectorType const & src) const final
   {

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_amg.h
@@ -182,6 +182,10 @@ public:
     }
   }
 
+  // Re-expose base overloads to avoid warning related to redefining `vmult()` with different
+  // signatures in based and derived class. Note that the number type is always `double`.
+  using PreconditionerBase<double>::vmult;
+
   void
   vmult(VectorType & dst, VectorType const & src) const override
   {
@@ -336,6 +340,10 @@ public:
     }
   }
 
+  // Re-expose base overloads to avoid warning related to redefining `vmult()` with different
+  // signatures in based and derived class.
+  using PreconditionerBase<Number>::vmult;
+
   void
   vmult(VectorType & dst, VectorType const & src) const override
   {
@@ -427,14 +435,14 @@ private:
 
   BoomerData boomer_data;
 
-  // PETSc vector objects to avoid re-allocation in every vmult() operation
+  // PETSc vector objects to avoid re-allocation in every `vmult()` operation.
   mutable Vec petsc_vector_src;
   mutable Vec petsc_vector_dst;
 };
 #endif
 
 /**
- * Implementation of AMG preconditioner unifying PreconditionerML and PreconditionerBoomerAMG.
+ * Implementation of AMG preconditioner unifying `PreconditionerML` and `PreconditionerBoomerAMG`.
  */
 template<typename Operator, typename Number>
 class PreconditionerAMG : public PreconditionerBase<Number>
@@ -474,6 +482,10 @@ public:
       AssertThrow(false, dealii::ExcNotImplemented());
     }
   }
+
+  // Re-expose base overloads to avoid warning related to redefining `vmult()` with different
+  // signatures in based and derived class.
+  using PreconditionerBase<Number>::vmult;
 
   void
   vmult(VectorType & dst, VectorType const & src) const final

--- a/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
+++ b/include/exadg/solvers_and_preconditioners/preconditioners/preconditioner_base.h
@@ -54,9 +54,8 @@ public:
   vmult(VectorType & dst, VectorType const & src) const = 0;
 
   /*
-   * This function applies the multigrid preconditioner dst = P^{-1} src and
-   * embedds the work schedule before/after the application (if supported by
-   * the preconditioner).
+   * This function applies the multigrid preconditioner dst = P^{-1} src and embeds the work
+   * schedule before/after the application (if supported by the preconditioner).
    */
   virtual void
   vmult(VectorType &                                                        dst,


### PR DESCRIPTION
this fixes the warnings  by explicitly `using` the base classes `vmult()` and then overwriting the `vmult()` with two arguments. This was the case because if a derived class declares a function with the _same name_, **all** base-class overloads with that name become hidden, unless explicitly brought into scope.