### PR TITLE
fix `BDFCoupledSolution`

### DIFF
--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_moving_mesh.output
@@ -193,65 +193,65 @@ Calculate error for pressure at time t = 0.0000e+00:
 
 ________________________________________________________________________________
 
- Time step number = 1       t = 0.00000e+00 -> t + dt = 8.50500e-03
+ Time step number = 1        advance to t + dt = 0.00000e+00 + 8.50500e-03
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0002e+00:
-  Relative error (L2-norm): 1.16663e-15
+  Relative error (L2-norm): 2.17048e-15
 
 Calculate error for pressure at time t = 1.0002e+00:
-  Relative error (L2-norm): 7.19724e-14
+  Relative error (L2-norm): 1.10892e-13
 
 Calculate error for velocity at time t = 2.0015e+00:
-  Relative error (L2-norm): 3.20915e-15
+  Relative error (L2-norm): 1.36593e-15
 
 Calculate error for pressure at time t = 2.0015e+00:
-  Relative error (L2-norm): 3.95144e-13
+  Relative error (L2-norm): 8.41968e-14
 
 Calculate error for velocity at time t = 3.0028e+00:
-  Relative error (L2-norm): 2.58172e-15
+  Relative error (L2-norm): 1.55120e-15
 
 Calculate error for pressure at time t = 3.0028e+00:
-  Relative error (L2-norm): 2.70744e-13
+  Relative error (L2-norm): 1.03482e-13
 
 Calculate error for velocity at time t = 4.0042e+00:
-  Relative error (L2-norm): 1.08736e-15
+  Relative error (L2-norm): 1.55260e-15
 
 Calculate error for pressure at time t = 4.0042e+00:
-  Relative error (L2-norm): 2.08174e-13
+  Relative error (L2-norm): 1.20227e-13
 
 Calculate error for velocity at time t = 5.0055e+00:
-  Relative error (L2-norm): 1.15175e-15
+  Relative error (L2-norm): 1.31207e-15
 
 Calculate error for pressure at time t = 5.0055e+00:
-  Relative error (L2-norm): 9.06785e-14
+  Relative error (L2-norm): 1.34778e-13
 
 Calculate error for velocity at time t = 6.0011e+00:
-  Relative error (L2-norm): 1.62575e-15
+  Relative error (L2-norm): 1.45687e-15
 
 Calculate error for pressure at time t = 6.0011e+00:
-  Relative error (L2-norm): 1.03348e-13
+  Relative error (L2-norm): 1.19875e-13
 
 Calculate error for velocity at time t = 7.0024e+00:
-  Relative error (L2-norm): 9.72181e-16
+  Relative error (L2-norm): 1.83840e-15
 
 Calculate error for pressure at time t = 7.0024e+00:
-  Relative error (L2-norm): 5.03529e-13
+  Relative error (L2-norm): 9.20858e-14
 
 Calculate error for velocity at time t = 8.0037e+00:
-  Relative error (L2-norm): 9.43933e-16
+  Relative error (L2-norm): 1.91233e-15
 
 Calculate error for pressure at time t = 8.0037e+00:
-  Relative error (L2-norm): 3.68435e-13
+  Relative error (L2-norm): 6.12702e-14
 
 Calculate error for velocity at time t = 9.0051e+00:
-  Relative error (L2-norm): 3.15058e-15
+  Relative error (L2-norm): 1.06015e-15
 
 Calculate error for pressure at time t = 9.0051e+00:
-  Relative error (L2-norm): 2.78289e-13
+  Relative error (L2-norm): 1.96512e-13
 
 Calculate error for velocity at time t = 1.0001e+01:
-  Relative error (L2-norm): 1.10732e-15
+  Relative error (L2-norm): 1.35344e-15
 
 Calculate error for pressure at time t = 1.0001e+01:
-  Relative error (L2-norm): 6.66685e-14
+  Relative error (L2-norm): 1.50773e-13

--- a/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
+++ b/applications/incompressible_navier_stokes/free_stream/tests/coupled_bdf2_static_mesh.output
@@ -191,7 +191,7 @@ Calculate error for pressure at time t = 0.0000e+00:
 
 ________________________________________________________________________________
 
- Time step number = 1       t = 0.00000e+00 -> t + dt = 8.50500e-03
+ Time step number = 1        advance to t + dt = 0.00000e+00 + 8.50500e-03
 ________________________________________________________________________________
 
 Calculate error for velocity at time t = 1.0036e+00:

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -133,20 +133,10 @@ OperatorCoupled<dim, Number>::setup_solver_coupled()
 
 template<int dim, typename Number>
 void
-OperatorCoupled<dim, Number>::update_divergence_penalty_operator(VectorType const &)
+OperatorCoupled<dim, Number>::update_penalty_operator(VectorType const & velocity,
+                                                      double const &     time_step_size)
 {
-  AssertThrow(false,
-              dealii::ExcMessage("This function is empty. Should it be filled or should we "
-                                 "put a comment here saying that no update is necessary?"));
-}
-
-template<int dim, typename Number>
-void
-OperatorCoupled<dim, Number>::update_continuity_penalty_operator(VectorType const &)
-{
-  AssertThrow(false,
-              dealii::ExcMessage("This function is empty. Should it be filled or should we "
-                                 "put a comment here saying that no update is necessary?"));
+  this->projection_operator->update(velocity, time_step_size);
 }
 
 template<int dim, typename Number>

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -225,18 +225,13 @@ private:
 
 public:
   /*
-   *  Update divergence penalty operator by recalculating the penalty parameter
-   *  which depends on the current velocity field
+   * Update the divergence and continuity penalty operator by recalculating the penalty parameter
+   * depending on the underlying settings, current velocity field and time step size. For
+   * instationary problems, an additional scaling by the time step size is useful, the time step
+   * size for stationary problems should be chosen as 1.0.
    */
   void
-  update_divergence_penalty_operator(VectorType const & velocity);
-
-  /*
-   *  Update continuity penalty operator by recalculating the penalty parameter
-   *  which depends on the current velocity field
-   */
-  void
-  update_continuity_penalty_operator(VectorType const & velocity);
+  update_penalty_operator(VectorType const & velocity, double const & time_step_size = 1.0);
 
   /*
    * Setters and getters.

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/projection_operator.cpp
@@ -196,7 +196,8 @@ ProjectionOperator<dim, Number>::do_cell_integral(IntegratorCell & integrator) c
 {
   for(unsigned int q = 0; q < integrator.n_q_points; ++q)
   {
-    integrator.submit_value(integrator.get_value(q), q);
+    if(operator_data.apply_penalty_terms_in_postprocessing_step)
+      integrator.submit_value(integrator.get_value(q), q);
 
     if(operator_data.use_divergence_penalty)
       integrator.submit_divergence(time_step_size * kernel->get_volume_flux(integrator, q), q);

--- a/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
@@ -135,10 +135,7 @@ DriverSteadyProblems<dim, Number>::do_solve(double const time, bool unsteady_pro
                 dealii::ExcMessage(
                   "Penalty terms have to be applied in momentum equation for steady problems."));
 
-    if(this->param.use_divergence_penalty == true)
-      pde_operator->update_divergence_penalty_operator(solution.block(0));
-    if(this->param.use_continuity_penalty == true)
-      pde_operator->update_continuity_penalty_operator(solution.block(0));
+    pde_operator->update_penalty_operator(solution.block(0));
   }
 
   // explicit viscosity update

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -209,14 +209,7 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
   // that these terms are added to the monolithic system of equations.
   if(this->param.apply_penalty_terms_in_postprocessing_step == false)
   {
-    if(this->param.use_divergence_penalty == true)
-    {
-      pde_operator->update_divergence_penalty_operator(solution_np.block(0));
-    }
-    if(this->param.use_continuity_penalty == true)
-    {
-      pde_operator->update_continuity_penalty_operator(solution_np.block(0));
-    }
+    pde_operator->update_penalty_operator(solution_np.block(0), this->get_time_step_size());
   }
 
   // update scaling factor of continuity equation


### PR DESCRIPTION
this is based on #14 since I was annoyed by the warnings.
once we have merged #14, let's look at this diff.

fix `BDFCoupledSolution` via:
- update the penalty parameters instead of doing nothing when calling `update_penalty_operator()`
- re-introduce the if-clause in `ProjectionOperator<dim, Number>::do_cell_integral()`. This `if` is necessary since we need to differentiate if the penalty terms are applied in **i)** a postprocessing step, or **ii)** included in the momentum operator. In the former case we add the mass matrix contribution, in the latter we skip it.