### PR TITLE
iNS: remove duplicate `update_projection_operator()` and fix some segfaults

### DIFF
--- a/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
+++ b/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
@@ -159,11 +159,11 @@ private:
     this->param.divu_formulation = FormulationVelocityDivergenceTerm::Weak;
 
     // div-div and continuity penalty
-    this->param.use_divergence_penalty                     = false;
-    this->param.divergence_penalty_factor                  = 1.0e0;
-    this->param.use_continuity_penalty                     = false;
-    this->param.continuity_penalty_factor                  = this->param.divergence_penalty_factor;
-    this->param.continuity_penalty_components              = ContinuityPenaltyComponents::Normal;
+    this->param.use_divergence_penalty        = spatial_discretization == SpatialDiscretization::L2;
+    this->param.divergence_penalty_factor     = 1.0e0;
+    this->param.use_continuity_penalty        = spatial_discretization == SpatialDiscretization::L2;
+    this->param.continuity_penalty_factor     = this->param.divergence_penalty_factor;
+    this->param.continuity_penalty_components = ContinuityPenaltyComponents::Normal;
     this->param.apply_penalty_terms_in_postprocessing_step = false;
     this->param.continuity_penalty_use_boundary_data       = false;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.cpp
@@ -74,7 +74,8 @@ OperatorCoupled<dim, Number>::setup_preconditioners_and_solvers()
 {
   Base::setup_preconditioners_and_solvers();
 
-  if(this->param.apply_penalty_terms_in_postprocessing_step)
+  if(this->param.apply_penalty_terms_in_postprocessing_step and
+     ((this->param.use_divergence_penalty == true or this->param.use_continuity_penalty == true)))
     Base::setup_projection_solver();
 
   setup_block_preconditioner();
@@ -114,14 +115,6 @@ OperatorCoupled<dim, Number>::setup_solver_coupled()
                                                     Krylov::SolverBase<BlockVectorType>>>(
       this->param.newton_solver_data_coupled, nonlinear_operator, linear_operator, *linear_solver);
   }
-}
-
-template<int dim, typename Number>
-void
-OperatorCoupled<dim, Number>::update_penalty_operator(VectorType const & velocity,
-                                                      double const &     time_step_size)
-{
-  this->projection_operator->update(velocity, time_step_size);
 }
 
 template<int dim, typename Number>
@@ -182,7 +175,8 @@ OperatorCoupled<dim, Number>::rhs_linear_problem(BlockVectorType &  dst,
     this->convective_operator.rhs_add(dst.block(0));
   }
 
-  if(this->param.apply_penalty_terms_in_postprocessing_step == false)
+  if(this->param.apply_penalty_terms_in_postprocessing_step == false and
+     (this->param.use_divergence_penalty == true or this->param.use_continuity_penalty == true))
   {
     this->projection_operator->set_time(time);
     this->projection_operator->rhs_add(dst.block(0));
@@ -208,7 +202,8 @@ OperatorCoupled<dim, Number>::apply_linearized_problem(BlockVectorType &       d
   this->momentum_operator.vmult(dst.block(0), src.block(0));
 
   // Divergence and continuity penalty operators
-  if(this->param.apply_penalty_terms_in_postprocessing_step == false)
+  if(this->param.apply_penalty_terms_in_postprocessing_step == false and
+     (this->param.use_divergence_penalty == true or this->param.use_continuity_penalty == true))
   {
     this->projection_operator->vmult_add(dst.block(0), src.block(0));
   }
@@ -285,7 +280,8 @@ OperatorCoupled<dim, Number>::evaluate_nonlinear_residual(BlockVectorType &     
   }
 
   // Divergence and continuity penalty operators
-  if(this->param.apply_penalty_terms_in_postprocessing_step == false)
+  if(this->param.apply_penalty_terms_in_postprocessing_step == false and
+     (this->param.use_divergence_penalty == true or this->param.use_continuity_penalty == true))
   {
     this->projection_operator->vmult_add(dst.block(0), src.block(0));
   }
@@ -349,7 +345,8 @@ OperatorCoupled<dim, Number>::evaluate_linearized_residual(BlockVectorType &    
   }
 
   // Divergence and continuity penalty operators
-  if(this->param.apply_penalty_terms_in_postprocessing_step == false)
+  if(this->param.apply_penalty_terms_in_postprocessing_step == false and
+     (this->param.use_divergence_penalty == true or this->param.use_continuity_penalty == true))
   {
     this->projection_operator->apply_add(dst.block(0), src.block(0));
   }
@@ -424,7 +421,8 @@ OperatorCoupled<dim, Number>::evaluate_nonlinear_residual_steady(BlockVectorType
   }
 
   // Divergence and continuity penalty operators
-  if(this->param.apply_penalty_terms_in_postprocessing_step == false)
+  if(this->param.apply_penalty_terms_in_postprocessing_step == false and
+     (this->param.use_divergence_penalty == true or this->param.use_continuity_penalty == true))
   {
     this->projection_operator->vmult_add(dst.block(0), src.block(0));
   }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operator_coupled.h
@@ -225,15 +225,6 @@ private:
 
 public:
   /*
-   * Update the divergence and continuity penalty operator by recalculating the penalty parameter
-   * depending on the underlying settings, current velocity field and time step size. For
-   * instationary problems, an additional scaling by the time step size is useful, the time step
-   * size for stationary problems should be chosen as 1.0.
-   */
-  void
-  update_penalty_operator(VectorType const & velocity, double const & time_step_size = 1.0);
-
-  /*
    * Setters and getters.
    */
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1101,6 +1101,7 @@ SpatialOperatorBase<dim, Number>::prescribe_initial_conditions(VectorType & velo
                         pressure,
                         field_functions->initial_solution_pressure,
                         time);
+
   // Set the constrained degrees of freedom to zero.
   for(unsigned int i : matrix_free->get_constrained_dofs(get_dof_index_velocity()))
     velocity.local_element(i) = 0.0;
@@ -1972,19 +1973,6 @@ double
 SpatialOperatorBase<dim, Number>::calculate_dissipation_divergence_term(
   VectorType const & /*velocity*/) const
 {
-  // // previous version was:
-  // if(param.use_divergence_penalty == true)
-  // {
-  //   VectorType dst;
-  //   dst.reinit(velocity, false);
-  //   div_penalty_operator.apply(dst, velocity);
-  //   return velocity * dst;
-  // }
-  // else
-  // {
-  //   return 0.0;
-  // }
-
   AssertThrow(param.use_divergence_penalty == false, dealii::ExcNotImplemented());
   return 0.0;
 }
@@ -1994,19 +1982,6 @@ double
 SpatialOperatorBase<dim, Number>::calculate_dissipation_continuity_term(
   VectorType const & /*velocity*/) const
 {
-  // // previous version was:
-  // if(param.use_continuity_penalty == true)
-  // {
-  //   VectorType dst;
-  //   dst.reinit(velocity, false);
-  //   conti_penalty_operator.apply(dst, velocity);
-  //   return velocity * dst;
-  // }
-  // else
-  // {
-  //   return 0.0;
-  // }
-
   AssertThrow(param.use_divergence_penalty == false, dealii::ExcNotImplemented());
   return 0.0;
 }
@@ -2255,7 +2230,7 @@ SpatialOperatorBase<dim, Number>::update_projection_operator(VectorType const & 
               dealii::ExcMessage("Projection operator is not initialized."));
 
   // Update projection operator, i.e., the penalty parameters that depend on the velocity field
-  // and the time step size
+  // and the time step size.
   projection_operator->update(velocity, time_step_size);
 }
 
@@ -2264,6 +2239,9 @@ void
 SpatialOperatorBase<dim, Number>::rhs_add_projection_operator(VectorType & dst,
                                                               double const time) const
 {
+  AssertThrow(projection_operator.get() != 0,
+              dealii::ExcMessage("Projection operator is not initialized."));
+
   projection_operator->set_time(time);
   projection_operator->rhs_add(dst);
 }

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.h
@@ -416,6 +416,13 @@ public:
   /*
    * Projection step.
    */
+
+  /*
+   * Update the divergence and continuity penalty operator by recalculating the penalty parameter
+   * depending on the underlying settings, current velocity field and time step size. For
+   * instationary problems, an additional scaling by the time step size is useful, the time step
+   * size for stationary problems should be chosen as 1.0.
+   */
   void
   update_projection_operator(VectorType const & velocity, double const time_step_size) const;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/driver_steady_problems.cpp
@@ -135,7 +135,7 @@ DriverSteadyProblems<dim, Number>::do_solve(double const time, bool unsteady_pro
                 dealii::ExcMessage(
                   "Penalty terms have to be applied in momentum equation for steady problems."));
 
-    pde_operator->update_penalty_operator(solution.block(0));
+    pde_operator->update_projection_operator(solution.block(0), 1.0 /* time_step_size */);
   }
 
   // explicit viscosity update

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_coupled_solver.cpp
@@ -207,9 +207,10 @@ TimeIntBDFCoupled<dim, Number>::do_timestep_solve()
 
   // Update divergence and continuity penalty operator in case
   // that these terms are added to the monolithic system of equations.
-  if(this->param.apply_penalty_terms_in_postprocessing_step == false)
+  if(this->param.apply_penalty_terms_in_postprocessing_step == false and
+     (this->param.use_divergence_penalty == true or this->param.use_continuity_penalty == true))
   {
-    pde_operator->update_penalty_operator(solution_np.block(0), this->get_time_step_size());
+    pde_operator->update_projection_operator(solution_np.block(0), this->get_time_step_size());
   }
 
   // update scaling factor of continuity equation


### PR DESCRIPTION
(this is not the PR where I add some simplifications/guides on how to use the restart mechanics)

- `OperatorCoupled::update_penalty_operator()` already existed in the base class as
`SpatailOperatorBase::update_projection_operator()` --> remove it

- one test that was added through the last merge w master uses no stabilization. The use of the `projection_operator` was not guarded by `use_continuity_penalty or use_divergence_penalty` --> add these `if` statements where needed.
Not sure if I got all places here, but we will see.

NOTE:
there are currently failing tests:
<img width="902" height="182" alt="image" src="https://github.com/user-attachments/assets/7753dc83-e232-4d64-80d2-b4a080326037" />
The ones that time out would probably run in `release` mode.
The `restart` ones are not updated yet.
`tests/vortex_periodic_HDIV_CoupledSolution.debug` is the only test that uses `HDIV` elements. There was some place where we said "this now breaks the standard approach". I forgot where this was.