### PR TITLE
iNS: remove u=0 on Dirichlet boundary after setting initial condition

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1101,9 +1101,6 @@ SpatialOperatorBase<dim, Number>::prescribe_initial_conditions(VectorType & velo
                         pressure,
                         field_functions->initial_solution_pressure,
                         time);
-  // Set the constrained degrees of freedom to zero.
-  for(unsigned int i : matrix_free->get_constrained_dofs(get_dof_index_velocity()))
-    velocity.local_element(i) = 0.0;
 
   // Compute initial variable viscosity using the initial velocity field.
   if(this->param.viscous_problem() and this->param.viscosity_is_variable())


### PR DESCRIPTION
I am not sure why this was introduced, for debugging maybe or because it gives values that are not exactly zero once RT elements are mapped ..?
In any case, I think it is wrong and should not be there for any case where the Dirichlet condition is inhomogeneous.
If the initial condition is zero, we are almost exclusively talking about practical cases, where one could also argue that the almost zero condition enforced through the interpolation is good enough.

Please explain if I misunderstood the purpose and/or reasoning behind.