### PR TITLE
iNS: enable convergence study w vortex periodic BC case

### DIFF
--- a/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
+++ b/applications/incompressible_navier_stokes/vortex_periodic_bc/application.h
@@ -111,6 +111,9 @@ public:
                         spatial_discretization,
                         "Type of spatial discretization.");
       prm.add_parameter("EndTime", end_time, "Simulation end time used.");
+      prm.add_parameter("OrderTimeIntegrator",
+                        order_time_integrator,
+                        "Order of the time integrator.");
     }
     prm.leave_subsection();
   }
@@ -142,7 +145,7 @@ private:
     this->param.cfl_exponent_fe_degree_velocity = 1.5;
     // this->param.time_step_size                  = 1.0e-7;
     this->param.adaptive_time_stepping_limiting_factor = 1.5;
-    this->param.order_time_integrator                  = 3;
+    this->param.order_time_integrator                  = order_time_integrator;
     this->param.start_with_low_order                   = false;
 
     // output of solver information
@@ -347,14 +350,22 @@ private:
     pp_data.error_data_u.time_control_data.start_time       = start_time;
     pp_data.error_data_u.time_control_data.trigger_interval = (end_time - start_time) / 20.0;
     pp_data.error_data_u.analytical_solution.reset(new AnalyticalSolutionVelocity<dim>(viscosity));
-    pp_data.error_data_u.name = "velocity";
+    pp_data.error_data_u.name                      = "velocity";
+    pp_data.error_data_u.compute_convergence_table = true;
+    pp_data.error_data_u.write_errors_to_file      = true;
+    pp_data.error_data_u.calculate_relative_errors = true;
+    pp_data.error_data_u.directory                 = this->output_parameters.directory;
 
     // ... pressure error
     pp_data.error_data_p.time_control_data.is_active        = true;
     pp_data.error_data_p.time_control_data.start_time       = start_time;
     pp_data.error_data_p.time_control_data.trigger_interval = (end_time - start_time);
     pp_data.error_data_p.analytical_solution.reset(new AnalyticalSolutionPressure<dim>(viscosity));
-    pp_data.error_data_p.name = "pressure";
+    pp_data.error_data_p.name                      = "pressure";
+    pp_data.error_data_p.compute_convergence_table = true;
+    pp_data.error_data_p.write_errors_to_file      = true;
+    pp_data.error_data_p.calculate_relative_errors = true;
+    pp_data.error_data_p.directory                 = this->output_parameters.directory;
 
     std::shared_ptr<PostProcessorBase<dim, Number>> pp;
     pp.reset(new PostProcessor<dim, Number>(pp_data, this->mpi_comm));
@@ -376,6 +387,8 @@ private:
 
   double const ABS_TOL_LINEAR = 1.e-12;
   double const REL_TOL_LINEAR = 1.e-2;
+
+  unsigned int order_time_integrator = 3;
 
   SpatialDiscretization spatial_discretization = SpatialDiscretization::HDIV;
 

--- a/applications/incompressible_navier_stokes/vortex_periodic_bc/input.json
+++ b/applications/incompressible_navier_stokes/vortex_periodic_bc/input.json
@@ -1,20 +1,23 @@
 {
     "General": {
         "Precision": "double",
-        "Dim": "2",
+        "Dim": "3",
         "IsTest": "false"
     },
     "SpatialResolution": {
-        "DegreeMin": "3",
-        "DegreeMax": "3",
-        "RefineSpaceMin": "3",
-        "RefineSpaceMax": "3"
+        "DegreeMin": "4",
+        "DegreeMax": "4",
+        "RefineSpaceMin": "1",
+        "RefineSpaceMax": "1"
     },
     "TemporalResolution": {
         "RefineTimeMin": "0",
         "RefineTimeMax": "0"
     },
     "Application": {
+        "EndTime": "0.5",
+        "TemporalDiscretization": "BDFConsistentSplittingExtruded",
+        "SpatialDiscretization": "HDIV",
         "MeshType": "Cartesian"
     },
     "Output": {

--- a/applications/incompressible_navier_stokes/vortex_periodic_bc/tests/vortex_periodic_HDIV_CoupledSolution.json
+++ b/applications/incompressible_navier_stokes/vortex_periodic_bc/tests/vortex_periodic_HDIV_CoupledSolution.json
@@ -15,6 +15,7 @@
         "RefineTimeMax": "0"
     },
     "Application": {
+        "OrderTimeIntegrator": "3",
         "EndTime": "0.5",
         "TemporalDiscretization": "BDFCoupledSolution",
         "SpatialDiscretization": "HDIV",

--- a/applications/incompressible_navier_stokes/vortex_periodic_bc/tests/vortex_periodic_HDIV_DualSplitting.json
+++ b/applications/incompressible_navier_stokes/vortex_periodic_bc/tests/vortex_periodic_HDIV_DualSplitting.json
@@ -15,6 +15,7 @@
         "RefineTimeMax": "0"
     },
     "Application": {
+        "OrderTimeIntegrator": "3",
         "EndTime": "0.5",
         "TemporalDiscretization": "BDFDualSplitting",
         "SpatialDiscretization": "HDIV",

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
@@ -1184,9 +1184,11 @@ public:
          const AffineConstraints<OtherNumber> & constraints,
          const std::vector<unsigned int> &      cell_vectorization_category,
          const Quadrature<1> &                  quadrature,
+         const bool                             is_test,
          const MPI_Comm                         communicator_shared = MPI_COMM_SELF)
   {
     (void)communicator_shared; // TODO: not yet implemented
+    this->is_test                                       = is_test;
     this->dof_handler                                   = &dof_handler;
     const FiniteElement<dim> &                       fe = dof_handler.get_fe();
     typename MatrixFree<dim, Number>::AdditionalData mf_data;
@@ -1372,7 +1374,7 @@ public:
 
   ~LaplaceOperatorDG()
   {
-    if(timings[0] > 0)
+    if(not this->is_test and timings[0] > 0)
     {
       const MPI_Comm comm = dof_handler->get_mpi_communicator();
       std::cout << std::defaultfloat << std::setprecision(3);
@@ -1394,7 +1396,7 @@ public:
       if(Utilities::MPI::this_mpi_process(comm) == 0)
         std::cout << std::endl;
     }
-    if(timings[10] > 0)
+    if(not this->is_test and timings[10] > 0)
     {
       const MPI_Comm comm       = MPI_COMM_WORLD;
       const double   total_time = Utilities::MPI::sum(timings[14], comm) / timings[10] /
@@ -1886,6 +1888,7 @@ public:
   }
 
 private:
+  bool                                   is_test;
   ObserverPointer<const DoFHandler<dim>> dof_handler;
   MatrixFree<dim, Number>                matrix_free;
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator_rt.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator_rt.h
@@ -293,9 +293,11 @@ public:
          const AffineConstraints<OtherNumber> & constraints,
          const std::vector<unsigned int> &      cell_vectorization_category,
          const Quadrature<1> &                  quadrature,
+         const bool                             is_test,
          const MPI_Comm                         communicator_shared = MPI_COMM_SELF)
   {
     (void)communicator_shared; // TODO: not yet implemented
+    this->is_test                 = is_test;
     this->mapping                 = &mapping;
     this->dof_handler             = &dof_handler;
     const FiniteElement<dim> & fe = dof_handler.get_fe();
@@ -665,7 +667,7 @@ public:
 
   ~RaviartThomasOperatorBase()
   {
-    if(timings[0] > 0)
+    if(not this->is_test and timings[0] > 0)
     {
       const MPI_Comm comm = dof_handler->get_mpi_communicator();
       std::cout << std::defaultfloat << std::setprecision(3);
@@ -688,7 +690,7 @@ public:
       if(Utilities::MPI::this_mpi_process(comm) == 0)
         std::cout << std::endl;
     }
-    if(timings[10] > 0)
+    if(not this->is_test and timings[10] > 0)
     {
       const MPI_Comm comm       = MPI_COMM_WORLD;
       const double   total_time = Utilities::MPI::sum(timings[14], comm) / timings[10] /
@@ -1623,6 +1625,7 @@ private:
     convective_and_divergence
   };
 
+  bool                                                             is_test;
   ObserverPointer<const Mapping<dim>>                              mapping;
   ObserverPointer<const DoFHandler<dim>>                           dof_handler;
   std::vector<dealii::ndarray<unsigned int, 2 * dim + 1, n_lanes>> dof_indices;

--- a/include/exadg/incompressible_navier_stokes/time_integration/helper_functions.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/helper_functions.h
@@ -50,6 +50,11 @@ extrapolate_vectors_range(
   std::vector<dealii::LinearAlgebra::distributed::Vector<Number>> const & vectors,
   dealii::LinearAlgebra::distributed::Vector<Number2> &                   result)
 {
+  AssertThrow(result.locally_owned_size() > 0,
+              dealii::ExcMessage("Result vector has not been initialized."));
+  for(auto const & vector : vectors)
+    AssertThrow(vector.locally_owned_size() > 0,
+                dealii::ExcMessage("Vector to extrapolate has not been initialized."));
   AssertIndexRange(start_index, result.locally_owned_size());
   AssertIndexRange(end_index, result.locally_owned_size() + 1);
   if(factors.size() == 1)

--- a/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
@@ -85,14 +85,16 @@ public:
     const std::vector<unsigned int> &                              cell_vectorization_category,
     const std::function<std::vector<dealii::Point<dim>>(
                                                         typename dealii::Triangulation<dim>::cell_iterator const)> & mapping_function,
-                          const Number ip_factor)
+                          const Number ip_factor,
+                          const bool is_test)
     : coarse_triangulations(
         dealii::MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(
           dof_handler.get_triangulation()/*,
                                            dealii::RepartitioningPolicyTools::MinimalGranularityPolicy<dim>(64)*/)),
       fe_hierarchy(create_fe_hierarchy(dof_handler.get_fe())),
       min_level(0),
-      max_level(dof_handler.get_triangulation().n_global_levels() - 1 + fe_hierarchy.max_level())
+      max_level(dof_handler.get_triangulation().n_global_levels() - 1 + fe_hierarchy.max_level()),
+      is_test(is_test)
   {
     dof_handler_hierarchy.resize(min_level, max_level);
 
@@ -244,7 +246,8 @@ public:
                      dof_handler,
                      empty_constraints,
                      cell_vectorization_category,
-                     dealii::QGauss<1>(dof_handler.get_fe().degree + 1));
+                     dealii::QGauss<1>(dof_handler.get_fe().degree + 1),
+                     this->is_test);
     dg_matrix.set_penalty_parameters(ip_factor);
     {
       typename SmootherTypeDG::AdditionalData smoother_data_dg;
@@ -296,7 +299,7 @@ public:
 
   ~PoissonPreconditionerMG()
   {
-    if(Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    if(not this->is_test and Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     {
       double all_time = 0;
       for(const auto & array : timings)
@@ -424,6 +427,8 @@ private:
 
   const unsigned int min_level;
   const unsigned int max_level;
+
+  bool const is_test;
 
   dealii::MGLevelObject<dealii::DoFHandler<dim>> dof_handler_hierarchy;
 

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
@@ -173,7 +173,8 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::allocate_vectors()
                 pde_operator->get_dof_handler_u(),
                 pde_operator->get_constraint_u(),
                 cell_vectorization_category,
-                dealii::QGauss<1>(pde_operator->get_dof_handler_u().get_fe().degree + 1));
+                dealii::QGauss<1>(pde_operator->get_dof_handler_u().get_fe().degree + 1),
+                this->is_test);
 
   op_rt->set_penalty_parameters(pde_operator->get_viscous_kernel_data().IP_factor);
   op_rt->initialize_dof_vector(solution_rt);
@@ -184,7 +185,8 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::allocate_vectors()
                       pde_operator->get_dof_handler_u(),
                       pde_operator->get_constraint_u(),
                       cell_vectorization_category,
-                      dealii::QGauss<1>(pde_operator->get_dof_handler_u().get_fe().degree + 1));
+                      dealii::QGauss<1>(pde_operator->get_dof_handler_u().get_fe().degree + 1),
+                      this->is_test);
 
   op_rt_float->set_penalty_parameters(pde_operator->get_viscous_kernel_data().IP_factor);
 
@@ -223,7 +225,8 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::allocate_vectors()
                      pde_operator->get_dof_handler_p(),
                      pde_operator->get_constraint_p(),
                      cell_vectorization_category,
-                     dealii::QGauss<1>(pde_operator->get_dof_handler_p().get_fe().degree + 1));
+                     dealii::QGauss<1>(pde_operator->get_dof_handler_p().get_fe().degree + 1),
+                     this->is_test);
   laplace_op->set_penalty_parameters(
     pde_operator->laplace_operator.get_data().kernel_data.IP_factor);
 
@@ -236,7 +239,8 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::allocate_vectors()
     pde_operator->get_dof_handler_p(),
     cell_vectorization_category,
     pde_operator->get_grid().mapping_function,
-    pde_operator->laplace_operator.get_data().kernel_data.IP_factor);
+    pde_operator->laplace_operator.get_data().kernel_data.IP_factor,
+    this->is_test);
 
   for(unsigned int i = 0; i < pressure.size(); ++i)
     poisson_preconditioner->get_dg_matrix().initialize_dof_vector(pressure[i]);

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
@@ -284,17 +284,34 @@ template<int dim, typename Number>
 void
 TimeIntBDFConsistentSplittingExtruded<dim, Number>::initialize_former_multistep_dof_vectors()
 {
-  // note that the loop begins with i=1! (we could also start with i=0 but this is not necessary)
+  // note that the loop begins with i=1, since i=0 is not necessary.
   for(unsigned int i = 1; i < velocity.size(); ++i)
   {
-    AssertThrow(false, dealii::ExcNotImplemented());
     if(this->param.ale_formulation)
       this->helpers_ale->move_grid(this->get_previous_time(i));
 
-    VectorType tmp;
-    tmp.reinit(velocity_np);
-    pde_operator->prescribe_initial_conditions(tmp, pressure_np, this->get_previous_time(i));
-    op_rt->copy_mf_to_this_vector(tmp, velocity[i]);
+    VectorType tmp_velocity, tmp_pressure;
+    tmp_velocity.reinit(velocity_np);
+    tmp_pressure.reinit(pressure_np);
+    pde_operator->prescribe_initial_conditions(tmp_velocity,
+                                               tmp_pressure,
+                                               this->get_previous_time(i));
+
+    // Copy vectors of `VectorType` to RT vector type.
+    op_rt->copy_mf_to_this_vector(tmp_velocity, velocity[i]);
+
+    // Convert `VectorType` to `VectorTypeFloat`, `pressure` has a fixed size unrelated to the
+    // extrapolation/integration order. Fill the entries that correspond to `velocity`.
+    pressure[i].copy_locally_owned_data_from(tmp_pressure);
+
+    // Construct pressure Neumann data vector, which has a number of entries depending on
+    // extrapolation order of the pressure for the Neumann BC, `order_extrapolation_pressure_nbc`.
+    if(i < pressure_nbc_rhs.size())
+      op_rt->evaluate_pressure_neumann_from_velocity(
+        velocity[i],
+        false,
+        this->pde_operator->get_viscous_kernel_data().viscosity,
+        pressure_nbc_rhs[i]);
   }
 }
 
@@ -495,20 +512,34 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::rhs_pressure(VectorType & rh
    */
   /*
    *  IV.1 compute curl-curl term by extrapolating the prepared values from
-   *  previous times
+   *  previous times, contributing on Dirichlet boundary
    */
-  factors.resize(extra_pressure_nbc.get_order());
-  for(unsigned int i = 0; i < extra_pressure_nbc.get_order(); ++i)
-    factors[i] = extra_pressure_nbc.get_beta(i);
-  extrapolate_vectors(factors, pressure_nbc_rhs, pressure_nbc_rhs.back());
-  op_rt->add_pressure_neumann_boundary_to_vector(pressure_nbc_rhs.back(), rhs);
+  if(not pde_operator->is_pressure_level_undefined())
+  {
+    factors.resize(extra_pressure_nbc.get_order());
+    for(unsigned int i = 0; i < extra_pressure_nbc.get_order(); ++i)
+      factors[i] = extra_pressure_nbc.get_beta(i);
 
-  /*
-   * IV.2 time derivative and contributions of Leray is disabled are ignored
-   * at this point -> TODO
-   */
+    extrapolate_vectors(factors, pressure_nbc_rhs, pressure_nbc_rhs.back());
+    op_rt->add_pressure_neumann_boundary_to_vector(pressure_nbc_rhs.back(), rhs);
+  }
 
-  // IV.3. pressure Dirichlet boundary conditions not done -> TODO
+  // If Leray projection is not applied then the contributions from the old time derivative do not
+  // cancel, so they have to be added
+  if(not this->param.apply_leray_projection)
+  {
+    // TODO
+    AssertThrow(false,
+                dealii::ExcMessage("Leray projection cancels some terms, "
+                                   "these are missing here."));
+  }
+
+  // IV.2. pressure Dirichlet boundary conditions
+  if(not pde_operator->is_pressure_level_undefined())
+  {
+    // TODO
+    AssertThrow(false, dealii::ExcMessage("Dirichlet BCs on the pressure are not implemented."));
+  }
 
   // special case: pressure level is undefined
   // Set mean value of rhs to zero in order to obtain a consistent linear system of equations.

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting_extruded.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_dual_splitting_extruded.cpp
@@ -134,7 +134,8 @@ TimeIntBDFDualSplittingExtruded<dim, Number>::allocate_vectors()
                 pde_operator->get_dof_handler_u(),
                 pde_operator->get_constraint_u(),
                 cell_vectorization_category,
-                dealii::QGauss<1>(pde_operator->get_dof_handler_u().get_fe().degree + 1));
+                dealii::QGauss<1>(pde_operator->get_dof_handler_u().get_fe().degree + 1),
+                this->is_test);
 
   op_rt->set_penalty_parameters(pde_operator->get_viscous_kernel_data().IP_factor);
   op_rt->initialize_dof_vector(solution_rt);
@@ -145,7 +146,8 @@ TimeIntBDFDualSplittingExtruded<dim, Number>::allocate_vectors()
                       pde_operator->get_dof_handler_u(),
                       pde_operator->get_constraint_u(),
                       cell_vectorization_category,
-                      dealii::QGauss<1>(pde_operator->get_dof_handler_u().get_fe().degree + 1));
+                      dealii::QGauss<1>(pde_operator->get_dof_handler_u().get_fe().degree + 1),
+                      this->is_test);
 
   op_rt_float->set_penalty_parameters(pde_operator->get_viscous_kernel_data().IP_factor);
 
@@ -187,7 +189,8 @@ TimeIntBDFDualSplittingExtruded<dim, Number>::allocate_vectors()
                      pde_operator->get_dof_handler_p(),
                      pde_operator->get_constraint_p(),
                      cell_vectorization_category,
-                     dealii::QGauss<1>(pde_operator->get_dof_handler_p().get_fe().degree + 1));
+                     dealii::QGauss<1>(pde_operator->get_dof_handler_p().get_fe().degree + 1),
+                     this->is_test);
   laplace_op->set_penalty_parameters(
     pde_operator->laplace_operator.get_data().kernel_data.IP_factor);
 
@@ -200,7 +203,8 @@ TimeIntBDFDualSplittingExtruded<dim, Number>::allocate_vectors()
     pde_operator->get_dof_handler_p(),
     cell_vectorization_category,
     pde_operator->get_grid().mapping_function,
-    pde_operator->laplace_operator.get_data().kernel_data.IP_factor);
+    pde_operator->laplace_operator.get_data().kernel_data.IP_factor,
+    this->is_test);
 
   for(unsigned int i = 0; i < pressure.size(); ++i)
     poisson_preconditioner->get_dg_matrix().initialize_dof_vector(pressure[i]);


### PR DESCRIPTION
- change standard input.json in vortex periodic BC to `dim=3` such that we can also run `BDFConsistentSplittingExtruded` by default
- add assert in the extrapolation routine in case the vector has not been setup
- add setup of initial condition from analytical solutions for `BDFConsistentSplittingExtruded`
- do not try to add curl-curl term = pressure term on Dirichlet boundary = pressure Neumann term if it does not exist. Previously we did the matrix-free loop and just did not add anything if we never hit the Dirichlet boundary. We have something similar now, but I wanted to skip the entire procedure of adding the term.
- adapt some `TODO`s to be more specific when it some things are missing and add `AssertThrow()` for these cases.
- suppress timings for `is_test == true`
- create files needed for automated convergence study
  
@gshubhamk @kronbichler 
this will be the case for convergence studies, first tests show that errors of `BDFConsistentSplittingExtruded` and `BDFDualSplitting` are similar, have to run these on the cluster. I will add a test for `BDFConsistentSplittingExtruded` for `applications/iNS/vortex_periodic_bc`. (`BDFCoupledSolution` fails as we know already)

The restart can also be tested with this to be absolutely sure that everything is correct. I will adapt the restart tests after doing a convergence study. 