### PR TITLE
Fix parallel restart

### DIFF
--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -308,6 +308,9 @@ private:
     this->param.restart_data.consider_mapping_read_target = de_serialize_in_deformed_geometry;
     this->param.restart_data.consider_restart_time_in_mesh_movement_function = false;
 
+    this->param.restart_data.solver_data.abs_tol        = 1e-20;
+    this->param.restart_data.solver_data.rel_tol        = 1e-12;
+    this->param.restart_data.solver_data.max_iter       = 1e3;
     this->param.restart_data.rpe_rtree_level            = 3;
     this->param.restart_data.rpe_tolerance_unit_cell    = 1e-6;
     this->param.restart_data.rpe_enforce_unique_mapping = false;
@@ -473,8 +476,11 @@ private:
         {
           // need to adjust for hierarchic numbering of
           // dealii::MappingQCache
-          points_moved[i] = manifold.push_forward(
-            fe_values.quadrature_point(hierarchic_to_lexicographic_numbering[i]));
+          if(consider_mapping)
+            points_moved[i] = manifold.push_forward(
+              fe_values.quadrature_point(hierarchic_to_lexicographic_numbering[i]));
+          else
+            points_moved[i] = fe_values.quadrature_point(hierarchic_to_lexicographic_numbering[i]);
         }
 
         return points_moved;
@@ -488,7 +494,10 @@ private:
       {
         // need to adjust for hierarchic numbering of
         // dealii::MappingQCache
-        points_moved[i] = manifold.push_forward(cell->vertex(i));
+        if(consider_mapping)
+          points_moved[i] = manifold.push_forward(cell->vertex(i));
+        else
+          points_moved[i] = cell->vertex(i);
       }
 
       return points_moved;
@@ -821,7 +830,8 @@ private:
   double       end_time           = end_time_multiples * flow_through_time;
 
   // grid
-  double grid_stretch_factor = 1.6;
+  bool const consider_mapping    = true;
+  double     grid_stretch_factor = 1.6;
 
   // dicretization
   TemporalDiscretization temporal_discretization = TemporalDiscretization::Undefined;

--- a/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
+++ b/include/exadg/acoustic_conservation_equations/spatial_discretization/spatial_operator.cpp
@@ -417,6 +417,7 @@ SpatialOperator<dim, Number>::deserialize_vectors(
     }
 
     ExaDG::GridToGridProjection::GridToGridProjectionData<dim> data;
+    data.solver_data                     = param.restart_data.solver_data;
     data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
     data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
     data.rpe_data.enforce_unique_mapping = param.restart_data.rpe_enforce_unique_mapping;

--- a/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
+++ b/include/exadg/compressible_navier_stokes/spatial_discretization/operator.cpp
@@ -489,6 +489,7 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
     }
 
     ExaDG::GridToGridProjection::GridToGridProjectionData<dim> data;
+    data.solver_data                     = param.restart_data.solver_data;
     data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
     data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
     data.rpe_data.enforce_unique_mapping = param.restart_data.rpe_enforce_unique_mapping;

--- a/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
+++ b/include/exadg/convection_diffusion/spatial_discretization/operator.cpp
@@ -698,6 +698,7 @@ Operator<dim, Number>::deserialize_vectors(std::vector<VectorType *> const & vec
     }
 
     ExaDG::GridToGridProjection::GridToGridProjectionData<dim> data;
+    data.solver_data                     = param.restart_data.solver_data;
     data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
     data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
     data.rpe_data.enforce_unique_mapping = param.restart_data.rpe_enforce_unique_mapping;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -141,19 +141,21 @@ SpatialOperatorBase<dim, Number>::project_to_restart_space(
   for(VectorType const * vec : src)
     vec->update_ghost_values();
 
-  // setup ``dealii::FEValues``
+  // setup `dealii::FEValues`
   dealii::FiniteElement<dim> const & fe_src = src_dof_handler.get_fe();
   dealii::FiniteElement<dim> const & fe_dst = dst_dof_handler_restart.get_fe();
-  dealii::FEValues<dim>              fe_values_src(src_mapping,
+
+  dealii::FEValues<dim> fe_values_src(src_mapping,
                                       fe_src,
                                       dealii::QGauss<dim>(fe_dst.degree + 1),
                                       dealii::update_values);
 
-  unsigned int const                           n_components  = fe_src.n_components();
-  unsigned int const                           dofs_per_cell = fe_dst.dofs_per_cell;
+  unsigned int const                           n_components = fe_src.n_components();
   std::vector<dealii::types::global_dof_index> dof_indices_dst(fe_dst.dofs_per_cell);
   std::vector<dealii::Tensor<1, dim>>          vector_values(fe_values_src.n_quadrature_points);
   std::vector<double>                          scalar_values(fe_values_src.n_quadrature_points);
+
+  AssertThrow(n_components == dim or n_components == 1, dealii::ExcNotImplemented());
 
   dealii::FEValuesExtractors::Vector const vector(0);
   dealii::FEValuesExtractors::Scalar const scalar(0);
@@ -178,7 +180,7 @@ SpatialOperatorBase<dim, Number>::project_to_restart_space(
 
         dealii::Utilities::MPI::Partitioner const & partitioner =
           *dst_restart[index].get_partitioner();
-        for(unsigned int i = 0; i < dofs_per_cell; ++i)
+        for(unsigned int i = 0; i < fe_dst.dofs_per_cell; ++i)
         {
           // We assume that the sequence of support points provided for
           // `dealii::FE_DGQArbitraryNodes` is unchanged from the ones passed
@@ -1359,8 +1361,8 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
 
     // Define grid-to-grid projection data for all projections used here.
     ExaDG::GridToGridProjection::GridToGridProjectionData<dim> projection_data;
-    projection_data.solver_data.abs_tol             = 1e-20;
-    projection_data.solver_data.rel_tol             = 1e-12;
+    projection_data.grids_and_maps_identical        = false;
+    projection_data.solver_data                     = param.restart_data.solver_data;
     projection_data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
     projection_data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
     projection_data.rpe_data.enforce_unique_mapping = param.restart_data.rpe_enforce_unique_mapping;
@@ -1384,10 +1386,6 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
                                      dof_handler_u_restart_intermediate,
                                      triangulation);
 
-      std::vector<VectorType const *> src;
-      for(VectorType const & vec : checkpoint_vectors_velocity)
-        src.push_back(&vec);
-
       checkpoint_vectors_velocity_intermediate.resize(checkpoint_vectors_velocity.size());
       for(VectorType & vec : checkpoint_vectors_velocity_intermediate)
         vec.reinit(dof_handler_u_restart_intermediate->locally_owned_dofs(),
@@ -1399,14 +1397,79 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
         checkpoint_triangulation->n_global_levels() == triangulation.n_global_levels() and
         checkpoint_triangulation->n_global_active_cells() == triangulation.n_global_active_cells();
 
-      if(spatial_resolution_identical == true)
+      if(false) // spatial_resolution_identical == true)
       {
+        // TODO: this is failing for high numbers of MPI ranks.
+        this->pcout << "\n"
+                    << "USING IDENTICAL GRID\n\n";
+
         // Use the projection onto the restart space with diagonal mass matrix.
+        std::vector<VectorType const *> src;
+        for(VectorType const & vec : checkpoint_vectors_velocity)
+          src.push_back(&vec);
+
+        this->pcout << "\n"
+                    << "VELOCITY PROJECTION TO INTERMEDIATE SPACE IN UNDEFORMED GRID\n\n";
+
         project_to_restart_space(src,
                                  *dof_handler_u_restart,
                                  *checkpoint_mapping,
                                  checkpoint_vectors_velocity_intermediate,
                                  *dof_handler_u_restart_intermediate);
+
+        this->pcout << "\n"
+                    << "PRESSURE PROJECTION IN UNDEFORMED GRID\n\n";
+        // We do not introduce an intermediate space for the pressure, project in the undeformed
+        // grid resetting the mapping in the `MatrixFree` object.
+        {
+          // Attaching manifolds, we assume that we at least refine once. We do not support
+          // coarsening (undoing the refinement without the manifold) and subsequent refinement.
+          dealii::Triangulation<dim> const & triangulation =
+            matrix_free->get_dof_handler().get_triangulation();
+          std::vector<dealii::types::manifold_id> manifold_ids = triangulation.get_manifold_ids();
+          AssertThrow(manifold_ids.size() == 1 and
+                        manifold_ids[0] == dealii::numbers::flat_manifold_id,
+                      dealii::ExcMessage("Combination of manifolds and grid-to-grid projection "
+                                         "in unmapped grid at restart not supported."));
+
+          // Create dummy linear mapping since we have no mapping serialized to restore.
+          std::shared_ptr<dealii::Mapping<dim>> default_mapping;
+          GridUtilities::create_mapping(default_mapping,
+                                        get_element_type(triangulation),
+                                        1 /* mapping_degree */);
+
+          // Update `MatrixFree` mapping, needs to be restored after grid-to-grid projection.
+          matrix_free_mutable->update_mapping(*default_mapping);
+
+          // Grid-to-grid projection for pressure to final finite element space. The DoFs can simply
+          // be used on the deformed grid, while projection is more stable in the undeformed
+          // configuration.
+          std::vector<std::vector<VectorType *>> source_vectors_per_dof_handler(1);
+          for(VectorType & vec : checkpoint_vectors_pressure)
+            source_vectors_per_dof_handler[0].push_back(&vec);
+
+          std::vector<std::vector<VectorType *>> target_vectors_per_dof_handler = {
+            vectors_pressure};
+
+          std::vector<dealii::DoFHandler<dim> const *> source_dof_handlers = {
+            dof_handler_p_restart.get()};
+
+          std::vector<dealii::DoFHandler<dim> const *> target_dof_handlers = {
+            &this->get_dof_handler_p()};
+
+          ExaDG::GridToGridProjection::do_grid_to_grid_projection<dim, Number, VectorType>(
+            checkpoint_mapping,
+            source_dof_handlers,
+            source_vectors_per_dof_handler,
+            target_dof_handlers,
+            *matrix_free,
+            target_vectors_per_dof_handler,
+            projection_data);
+
+          // Restore the mapping in `MatrixFree` to continue with the requested mapping after
+          // restart.
+          matrix_free_mutable->update_mapping(*this->get_mapping());
+        }
       }
       else
       {
@@ -1428,20 +1491,28 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
           target_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
         }
 
-        std::vector<std::vector<VectorType *>> source_vectors_per_dof_handler(1);
+        // Grid-to-grid projection in undeformed configuration: velocity to intermediate space and
+        // pressure to final space. The pressure DoFs can simply be used on the deformed grid, while
+        // projection is more stable in the undeformed configuration.
+        std::vector<std::vector<VectorType *>> source_vectors_per_dof_handler(2);
         for(VectorType & vec : checkpoint_vectors_velocity)
-          source_vectors_per_dof_handler[0].push_back(&vec);
+          source_vectors_per_dof_handler[0 /* velocity */].push_back(&vec);
+        for(VectorType & vec : checkpoint_vectors_pressure)
+          source_vectors_per_dof_handler[1 /* pressure */].push_back(&vec);
 
-        std::vector<std::vector<VectorType *>> target_vectors_per_dof_handler(1);
+        std::vector<std::vector<VectorType *>> target_vectors_per_dof_handler(2);
         for(VectorType & vec : checkpoint_vectors_velocity_intermediate)
           target_vectors_per_dof_handler[0].push_back(&vec);
+        target_vectors_per_dof_handler[1] = vectors_pressure;
 
         std::vector<dealii::DoFHandler<dim> const *> source_dof_handlers = {
-          dof_handler_u_restart.get()};
+          dof_handler_u_restart.get(), dof_handler_p_restart.get()};
 
         std::vector<dealii::DoFHandler<dim> const *> target_dof_handlers = {
-          dof_handler_u_restart_intermediate.get()};
+          dof_handler_u_restart_intermediate.get(), &this->get_dof_handler_p()};
 
+        this->pcout << "\n"
+                    << "PROJECTION IN UNDEFORMED GRID\n\n";
         ExaDG::GridToGridProjection::grid_to_grid_projection<dim, Number, VectorType>(
           checkpoint_mapping,
           source_dof_handlers,
@@ -1452,23 +1523,40 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
           projection_data);
       }
 
-      // Perform the grid-to-grid projection on the deformed grid, but between grids that have the
-      // same refinement level and mapping to improve stability.
-      checkpoint_mapping                        = this->get_mapping();
-      checkpoint_dof_handlers[0 /* velocity */] = dof_handler_u_restart_intermediate.get();
-      std::vector<VectorType *> checkpoint_vectors_velocity_intermediate_ptr;
+      // Perform the grid-to-grid projection on the deformed grid to the final velocity space,
+      // but between grids that have the same refinement level and mapping to improve stability by
+      // *avoiding* `dealii::RemotePointEvaluation`.
+      projection_data.grids_and_maps_identical = true;
+
+      this->pcout << "\n"
+                  << "VELOCITY PROJECTION IN DEFORMED GRID\n\n";
+
+      checkpoint_mapping = this->get_mapping();
+
+      std::vector<std::vector<VectorType *>> source_vectors_per_dof_handler(1);
       for(VectorType & vec : checkpoint_vectors_velocity_intermediate)
-        checkpoint_vectors_velocity_intermediate_ptr.push_back(&vec);
-      checkpoint_vectors[0 /* velocity */] = checkpoint_vectors_velocity_intermediate_ptr;
+        source_vectors_per_dof_handler[0].push_back(&vec);
+
+      std::vector<std::vector<VectorType *>> target_vectors_per_dof_handler = {vectors_velocity};
+
+      std::vector<dealii::DoFHandler<dim> const *> source_dof_handlers = {
+        dof_handler_u_restart_intermediate.get()};
+
+      std::vector<dealii::DoFHandler<dim> const *> target_dof_handlers = {
+        &this->get_dof_handler_u()};
 
       ExaDG::GridToGridProjection::do_grid_to_grid_projection<dim, Number, VectorType>(
         checkpoint_mapping,
-        checkpoint_dof_handlers,
-        checkpoint_vectors,
-        dof_handlers,
+        source_dof_handlers,
+        source_vectors_per_dof_handler,
+        target_dof_handlers,
         *matrix_free,
-        vectors_per_dof_handler,
+        target_vectors_per_dof_handler,
         projection_data);
+
+      // Set pointers to velocity vectors for plotting.
+      checkpoint_vectors[0 /* velocity */]      = source_vectors_per_dof_handler[0];
+      checkpoint_dof_handlers[0 /* velocity */] = source_dof_handlers[0];
     }
     else
     {
@@ -1527,6 +1615,17 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
       output_data.directory = "output/";
       output_data.degree    = param.degree_u;
       std::vector<bool> component_is_part_of_vector(dim, true);
+
+      if(this->param.restart_data.consider_mapping_read_target == false and
+         this->param.spatial_discretization == SpatialDiscretization::HDIV)
+      {
+        // TODO: keep the `checkpoint_mapping`.
+        std::shared_ptr<dealii::Mapping<dim>> tmp;
+        GridUtilities::create_mapping(tmp,
+                                      get_element_type(*checkpoint_triangulation),
+                                      1 /* mapping_degree */);
+        checkpoint_mapping = std::const_pointer_cast<dealii::Mapping<dim> const>(tmp);
+      }
 
       {
         output_data.filename = "projected_velocity_read_restart";

--- a/include/exadg/operators/inverse_mass_operator.cpp
+++ b/include/exadg/operators/inverse_mass_operator.cpp
@@ -76,6 +76,9 @@ InverseMassOperator<dim, n_components, Number>::initialize(
       dealii::ExcMessage(
         "The matrix-free cell-wise inverse mass operator is only available for L2-conforming elements."));
 
+    // Store `0` to signal that no global iterations are done.
+    this->n_iter_global_last = 0;
+
     if(fe.reference_cell().is_hyper_cube())
     {
       AssertThrow(

--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -24,6 +24,7 @@
 
 // C/C++
 #include <algorithm>
+#include <chrono>
 
 // deal.II
 #include <deal.II/base/conditional_ostream.h>
@@ -56,16 +57,21 @@ struct GridToGridProjectionData
       solver_data(SolverData(1e3, 1e-20, 1e-6, LinearSolver::CG)),
       preconditioner(PreconditionerMass::PointJacobi),
       amg_data(AMGData()),
-      additional_quadrature_points(1)
+      additional_quadrature_points(1),
+      grids_and_maps_identical(false)
   {
   }
 
   void
   print(dealii::ConditionalOStream const & pcout) const
   {
-    print_parameter(pcout, "RPE tolerance", rpe_data.tolerance);
-    print_parameter(pcout, "RPE enforce unique mapping", rpe_data.enforce_unique_mapping);
-    print_parameter(pcout, "RPE rtree level", rpe_data.rtree_level);
+    print_parameter(pcout, "Grids and maps are assumed identical", grids_and_maps_identical);
+    if(not grids_and_maps_identical)
+    {
+      print_parameter(pcout, "RPE tolerance", rpe_data.tolerance);
+      print_parameter(pcout, "RPE enforce unique mapping", rpe_data.enforce_unique_mapping);
+      print_parameter(pcout, "RPE rtree level", rpe_data.rtree_level);
+    }
 
     // These parameters play only a role if an iterative scheme is used for projection.
     // That is for `InverseMassType != InverseMassType::MatrixfreeOperator` determined at runtime.
@@ -83,11 +89,15 @@ struct GridToGridProjectionData
   // The default `additional_quadrature_points = 1` considers `fe_degree + 1` quadrature points in
   // 1D using the `fe_degree` of the target grid's finite element.
   unsigned int additional_quadrature_points;
+
+  // Having identical grids and mappings, one can avoid RPE for mapped configurations. This flag has
+  // to be provided by the user, to avoid an expensive check for independent copies of identical
+  // grids and mappings.
+  bool grids_and_maps_identical;
 };
 
 /**
- * Utility function to collect integration points in the exact sequence they are encountered
- * in.
+ * Utility function to collect integration points in the exact sequence they are encountered in.
  */
 template<int dim, int n_components, typename Number>
 std::vector<dealii::Point<dim>>
@@ -125,6 +135,96 @@ collect_integration_points(
   }
 
   return integration_points;
+}
+
+/**
+ * Utility function to compute the right-hand side of a projection (mass matrix solve), assuming the
+ * `dealii::DoFHandler`s corresponding to *identical* grids with *identical* mappings, which are
+ * distributed *identically*. The function space, however, might be different. We interpolate the
+ * source and assemble the projection right-hand side with the target finite element.
+ */
+template<int dim, int n_components, typename Number, typename VectorType>
+VectorType
+assemble_projection_rhs(VectorType &                              system_rhs,
+                        VectorType const &                        source_vector,
+                        dealii::DoFHandler<dim> const &           source_dof_handler,
+                        dealii::Mapping<dim> const &              source_and_target_mapping,
+                        dealii::DoFHandler<dim> const &           target_dof_handler,
+                        dealii::AffineConstraints<Number> const & target_constraints,
+                        dealii::Quadrature<dim> const &           quadrature)
+{
+  // Check if the triangulations *might* be identical, assuming there is no adaptive refinement.
+  dealii::Triangulation<dim> const & source_triangulation = source_dof_handler.get_triangulation();
+  dealii::Triangulation<dim> const & target_triangulation = target_dof_handler.get_triangulation();
+  bool const                         spatial_resolution_identical =
+    source_triangulation.n_global_levels() == target_triangulation.n_global_levels() and
+    source_triangulation.n_global_active_cells() == target_triangulation.n_global_active_cells();
+  AssertThrow(spatial_resolution_identical == true,
+              dealii::ExcMessage("The triangulations used cannot be identical."));
+
+  dealii::FiniteElement<dim> const & source_fe = source_dof_handler.get_fe();
+  dealii::FiniteElement<dim> const & target_fe = target_dof_handler.get_fe();
+
+  dealii::FEValues<dim> fe_values_source(source_and_target_mapping,
+                                         source_fe,
+                                         quadrature,
+                                         dealii::update_values);
+  dealii::FEValues<dim> fe_values_target(source_and_target_mapping,
+                                         target_fe,
+                                         quadrature,
+                                         dealii::update_values | dealii::update_JxW_values);
+
+  unsigned int const dofs_per_cell = target_fe.dofs_per_cell;
+  unsigned int const n_q_points    = quadrature.size();
+
+  std::vector<dealii::types::global_dof_index> dof_indices(dofs_per_cell);
+  std::vector<dealii::Tensor<1, dim>> vector_values_source(fe_values_source.n_quadrature_points);
+  std::vector<double>                 scalar_values_source(fe_values_source.n_quadrature_points);
+
+  dealii::FEValuesExtractors::Vector const vector(0);
+  dealii::FEValuesExtractors::Scalar const scalar(0);
+
+  dealii::Vector<double> cell_rhs(dofs_per_cell);
+
+  AssertThrow(n_components == dim or n_components == 1, dealii::ExcNotImplemented());
+
+  for(const auto & cell_target : target_dof_handler.active_cell_iterators())
+  {
+    const auto cell_source = cell_target->as_dof_handler_iterator(source_dof_handler);
+    if(cell_target->is_locally_owned())
+    {
+      fe_values_source.reinit(cell_source);
+      fe_values_target.reinit(cell_target);
+
+      cell_rhs = 0.0;
+
+      if constexpr(n_components == dim)
+      {
+        fe_values_source[vector].get_function_values(source_vector, vector_values_source);
+
+        for(unsigned int q = 0; q < n_q_points; ++q)
+          for(unsigned int i = 0; i < dofs_per_cell; ++i)
+            cell_rhs[i] += vector_values_source[q] * fe_values_target[vector].value(i, q) *
+                           fe_values_target.JxW(q);
+      }
+      else
+      {
+        fe_values_source[scalar].get_function_values(source_vector, scalar_values_source);
+
+        for(unsigned int q = 0; q < n_q_points; ++q)
+          for(unsigned int i = 0; i < dofs_per_cell; ++i)
+            cell_rhs[i] += scalar_values_source[q] * fe_values_target[scalar].value(i, q) *
+                           fe_values_target.JxW(q);
+      }
+
+      // Assemble ignoring constraints as `dealii::MatrixFree` resolves constraints.
+      cell_target->get_dof_indices(dof_indices);
+      target_constraints.distribute_local_to_global(cell_rhs, dof_indices, system_rhs);
+    }
+  }
+  system_rhs.compress(dealii::VectorOperation::add);
+
+  return system_rhs;
 }
 
 /**
@@ -225,71 +325,131 @@ project_vectors(
   InverseMassOperator<dim, n_components, Number> inverse_mass_operator;
   inverse_mass_operator.initialize(target_matrix_free, inverse_mass_operator_data);
 
-  dealii::Utilities::MPI::RemotePointEvaluation<dim> rpe_source(data.rpe_data);
+  MPI_Comm const             mpi_comm = source_dof_handler.get_mpi_communicator();
+  dealii::ConditionalOStream pcout(std::cout,
+                                   (dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0));
+  pcout << std::scientific << std::setprecision(4);
+  std::chrono::time_point<std::chrono::high_resolution_clock> time_start, time_end;
 
-  // The sequence of integration points follows from the sequence of points as encountered during
-  // cell batch loop.
-  std::vector<dealii::Point<dim>> integration_points_target =
-    collect_integration_points<dim, n_components, Number>(target_matrix_free,
-                                                          dof_index,
-                                                          quad_index);
-
-  rpe_source.reinit(integration_points_target,
-                    source_dof_handler.get_triangulation(),
-                    *source_mapping);
-
-  if(not rpe_source.all_points_found())
+  // If the grids and maps are *not* identical, interpolate the source grid in the target grid's
+  // integration points using `dealii::RemotePointEvaluation`.
+  std::shared_ptr<dealii::Utilities::MPI::RemotePointEvaluation<dim>> rpe_source =
+    std::make_shared<dealii::Utilities::MPI::RemotePointEvaluation<dim>>(data.rpe_data);
+  if(not data.grids_and_maps_identical)
   {
-    write_points_in_dummy_triangulation(
-      integration_points_target, "./", "points_all", 0, source_dof_handler.get_mpi_communicator());
+    // The sequence of integration points follows from the sequence of points as encountered during
+    // cell batch loop.
+    std::vector<dealii::Point<dim>> integration_points_target =
+      collect_integration_points<dim, n_components, Number>(target_matrix_free,
+                                                            dof_index,
+                                                            quad_index);
 
-    std::vector<dealii::Point<dim>> points_not_found;
-    points_not_found.reserve(integration_points_target.size());
-    for(unsigned int i = 0; i < integration_points_target.size(); ++i)
+    time_start = std::chrono::high_resolution_clock::now();
+    rpe_source->reinit(integration_points_target,
+                       source_dof_handler.get_triangulation(),
+                       *source_mapping);
+    time_end = std::chrono::high_resolution_clock::now();
+
+    std::chrono::duration<double> time_elapsed_rpe_reinit = time_end - time_start;
+
+    pcout << "time: RPE reinit         " << time_elapsed_rpe_reinit.count() << " s\n";
+
+    if(not rpe_source->all_points_found())
     {
-      if(not rpe_source.point_found(i))
+      write_points_in_dummy_triangulation(integration_points_target,
+                                          "./",
+                                          "points_all",
+                                          dealii::Utilities::MPI::this_mpi_process(mpi_comm),
+                                          mpi_comm);
+
+      std::vector<dealii::Point<dim>> points_not_found;
+      points_not_found.reserve(integration_points_target.size());
+      for(unsigned int i = 0; i < integration_points_target.size(); ++i)
       {
-        points_not_found.push_back(integration_points_target[i]);
+        if(not rpe_source->point_found(i))
+        {
+          points_not_found.push_back(integration_points_target[i]);
+        }
       }
+
+      write_points_in_dummy_triangulation(points_not_found, "./", "points_not_found", 0, mpi_comm);
+
+      MPI_Barrier(mpi_comm);
+
+      AssertThrow(
+        rpe_source->all_points_found(),
+        dealii::ExcMessage(
+          "Could not interpolate source grid vector in target grid. "
+          "Points exported to `./points_all_points.pvtu` and `./points_not_found_points.pvtu`"));
     }
-
-    write_points_in_dummy_triangulation(
-      points_not_found, "./", "points_not_found", 0, source_dof_handler.get_mpi_communicator());
-
-    MPI_Barrier(source_dof_handler.get_mpi_communicator());
-
-    AssertThrow(
-      rpe_source.all_points_found(),
-      dealii::ExcMessage(
-        "Could not interpolate source grid vector in target grid. "
-        "Points exported to `./points_all_points.pvtu` and `./points_not_found_points.pvtu`"));
   }
 
   // Loop over vectors and project.
+  double time_elapsed_rpe_interpolate    = 0.0;
+  double time_elapsed_inverse_mass_rhs   = 0.0;
+  double time_elapsed_inverse_mass_apply = 0.0;
   for(unsigned int i = 0; i < target_vectors.size(); ++i)
   {
     // Evaluate the source vector at the target integration points.
     VectorType const & source_vector = *source_vectors.at(i);
     source_vector.update_ghost_values();
 
-    std::vector<
-      typename dealii::FEPointEvaluation<n_components, dim, dim, Number>::value_type> const
-      values_source_in_q_points_target = dealii::VectorTools::point_values<n_components>(
-        rpe_source, source_dof_handler, source_vector, dealii::VectorTools::EvaluationFlags::avg);
+    // Assemble right-hand side for the projection.
+    VectorType system_rhs;
+    if(data.grids_and_maps_identical)
+    {
+      time_start = std::chrono::high_resolution_clock::now();
+      target_matrix_free.initialize_dof_vector(system_rhs, dof_index);
+      assemble_projection_rhs<dim, n_components, Number, VectorType>(
+        system_rhs,
+        source_vector,
+        source_dof_handler,
+        *source_mapping /* source_and_target_mapping */,
+        target_matrix_free.get_dof_handler(dof_index),
+        target_matrix_free.get_affine_constraints(dof_index),
+        target_matrix_free.get_quadrature(quad_index));
+      time_end = std::chrono::high_resolution_clock::now();
+      time_elapsed_inverse_mass_rhs += std::chrono::duration<double>(time_end - time_start).count();
+    }
+    else
+    {
+      time_start = std::chrono::high_resolution_clock::now();
+      std::vector<
+        typename dealii::FEPointEvaluation<n_components, dim, dim, Number>::value_type> const
+        values_source_in_q_points_target = dealii::VectorTools::point_values<n_components>(
+          *rpe_source,
+          source_dof_handler,
+          source_vector,
+          dealii::VectorTools::EvaluationFlags::avg);
+      time_end = std::chrono::high_resolution_clock::now();
+      time_elapsed_rpe_interpolate += std::chrono::duration<double>(time_end - time_start).count();
 
-    // Assemble right-hand side vector for the projection.
-    VectorType system_rhs = assemble_projection_rhs<dim, n_components, Number, VectorType>(
-      target_matrix_free, values_source_in_q_points_target, dof_index, quad_index);
+      time_start = std::chrono::high_resolution_clock::now();
+      system_rhs = assemble_projection_rhs<dim, n_components, Number, VectorType>(
+        target_matrix_free, values_source_in_q_points_target, dof_index, quad_index);
+      time_end = std::chrono::high_resolution_clock::now();
+      time_elapsed_inverse_mass_rhs += std::chrono::duration<double>(time_end - time_start).count();
+    }
 
     // Solve linear system starting from zero initial guess.
     VectorType sol;
     sol.reinit(system_rhs, false /* omit_zeroing_entries */);
 
+    time_start = std::chrono::high_resolution_clock::now();
     inverse_mass_operator.apply(sol, system_rhs);
+    time_end = std::chrono::high_resolution_clock::now();
+    time_elapsed_inverse_mass_apply += std::chrono::duration<double>(time_end - time_start).count();
+
+    pcout << "global CG iterations in projection : "
+          << inverse_mass_operator.get_n_iter_global_last() << "\n";
 
     // Copy solution to target vector.
     *target_vectors[i] = sol;
   }
+
+  pcout << "time: RPE interpolate    " << time_elapsed_rpe_interpolate << " s\n";
+  pcout << "time: inverse mass rhs   " << time_elapsed_inverse_mass_rhs << " s\n";
+  pcout << "time: inverse mass apply " << time_elapsed_inverse_mass_apply << " s\n";
 }
 
 /**

--- a/include/exadg/time_integration/restart_data.h
+++ b/include/exadg/time_integration/restart_data.h
@@ -31,6 +31,7 @@
 // ExaDG
 #include <exadg/grid/grid_data.h>
 #include <exadg/incompressible_navier_stokes/user_interface/enum_types.h>
+#include <exadg/solvers_and_preconditioners/solvers/solver_data.h>
 #include <exadg/utilities/numbers.h>
 #include <exadg/utilities/print_functions.h>
 #include <exadg/utilities/serializable_function.h>
@@ -139,7 +140,8 @@ struct RestartData
       consider_restart_time_in_mesh_movement_function(true),
       rpe_rtree_level(0),
       rpe_tolerance_unit_cell(1e-12),
-      rpe_enforce_unique_mapping(false)
+      rpe_enforce_unique_mapping(false),
+      solver_data(SolverData(1e3, 1e-20, 1e-6, LinearSolver::CG))
   {
   }
 
@@ -280,6 +282,9 @@ struct RestartData
   unsigned int rpe_rtree_level;
   double       rpe_tolerance_unit_cell;
   bool         rpe_enforce_unique_mapping;
+
+  // Settings for Krylov solver used in case grid-to-grid projection is necessary.
+  SolverData solver_data;
 };
 
 } // namespace ExaDG


### PR DESCRIPTION
based on #21 

in addition to my e-mail, I did some tests on my laptop (as the problems are evident also at smaller scales):

**for the fast path** (disabled in this PR): I am not sure the error is happening in the `project_to_restart_space()`. the output I got hinted at the fact that some cache is not of the right size in RPE.
<img width="1036" height="606" alt="image" src="https://github.com/user-attachments/assets/dd6170a2-cfbc-489f-b555-6e7482533c0a" />
`std::bad_array_new_length`

and also

<img width="1235" height="628" alt="image" src="https://github.com/user-attachments/assets/6845f5b7-b0ba-4fce-b4da-573e62086b54" />

**also**, using $n$ mpi ranks o $m$ some times leads to me finding all points or not ... that is another problem

**also**, it seemed that using identical grids, but a strong mapping sometimes leads to some points not being found ... that is another problem

**for the slow path** I am sure it is RPE, specifically `rpe.reinit()`. I do not even reach

<img width="829" height="254" alt="image" src="https://github.com/user-attachments/assets/c1c188be-cc07-42b6-9455-f099c5a2c15d" />

for a 25e6 DoF grid using the mapping. **not** using the mapping, this takes 3.4 seconds:
<img width="413" height="251" alt="image" src="https://github.com/user-attachments/assets/a8bf6517-e33f-4b96-b690-dfd831a93eab" />

---------------------------------
OPTION A: debug RPE, also maybe I am using it wrong?
OPTION B:
Since on the undeformed grid performance seems ok (i guess?) and one can reliably find all points,I propose to avoid RPE for the deformed grid, using RPE only in the reference geometry and then using identical grids in the deformed geometry only (where an assembly function is **MISSING**). THAT SHOULD WORK! We can assemble a suitable rhs in a projection easily without RPE if we have the same grid.

I will try to do Option B tomorrow.
@kronbichler can you double-check these timings with this branch?
and should we write a mwe to open an issue in deal.II?