### PR TITLE
 Make compile for new deal.II version 

### DIFF
--- a/include/exadg/operators/interior_penalty_parameter.h
+++ b/include/exadg/operators/interior_penalty_parameter.h
@@ -58,12 +58,11 @@ calculate_penalty_parameter(
     matrix_free.get_dof_handler(dof_index).get_triangulation().get_reference_cells();
   AssertThrow(reference_cells.size() == 1, dealii::ExcMessage("No mixed meshes allowed."));
 
-  auto const quadrature = reference_cells[0].template get_gauss_type_quadrature<dim>(degree + 1);
+  auto const            quadrature = reference_cells[0].get_gauss_type_quadrature(degree + 1);
   dealii::FEValues<dim> fe_values(mapping, fe, quadrature, dealii::update_JxW_values);
 
   auto const face_quadrature =
-    reference_cells[0].face_reference_cell(0).template get_gauss_type_quadrature<dim - 1>(degree +
-                                                                                          1);
+    reference_cells[0].face_reference_cell(0).get_gauss_type_quadrature(degree + 1);
   dealii::FEFaceValues<dim> fe_face_values(mapping, fe, face_quadrature, dealii::update_JxW_values);
 
   for(unsigned int i = 0; i < n_cells; ++i)

--- a/include/exadg/operators/inverse_mass_operator.cpp
+++ b/include/exadg/operators/inverse_mass_operator.cpp
@@ -121,7 +121,7 @@ InverseMassOperator<dim, n_components, Number>::initialize(
 
         const dealii::MappingFE<dim, dim> mapping_mass(scalar_fe);
         const auto                        quadrature_mass =
-          scalar_fe.reference_cell().template get_gauss_type_quadrature<dim>(scalar_fe.degree + 1);
+          scalar_fe.reference_cell().get_gauss_type_quadrature(scalar_fe.degree + 1);
 
         dealii::FEValues<dim> fe_values(mapping_mass,
                                         scalar_fe,

--- a/include/exadg/poisson/user_interface/application_base.h
+++ b/include/exadg/poisson/user_interface/application_base.h
@@ -112,8 +112,7 @@ public:
       auto const reference_cells = grid->triangulation->get_reference_cells();
       AssertThrow(reference_cells.size() == 1, dealii::ExcMessage("No mixed meshes allowed"));
 
-      auto const quad =
-        reference_cells[0].template get_gauss_type_quadrature<dim>(param.degree + 1);
+      auto const quad = reference_cells[0].get_gauss_type_quadrature(param.degree + 1);
 
       double const aspect_ratio =
         dealii::GridTools::compute_maximum_aspect_ratio(*mapping, *grid->triangulation, quad);


### PR DESCRIPTION
In deal.II, the `ReferenceCell` class has been given a template, see the current documentation: https://dealii.org/developer/doxygen/deal.II/classReferenceCell.html 
As a consequence, some functions we're using do not require the template argument any more. Adjust those to make the code compatible with deal.II master.