### PR TITLE
Speed up computation of projection rhs

### DIFF
--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -151,7 +151,7 @@ assemble_projection_rhs(VectorType &                              system_rhs,
                         dealii::Mapping<dim> const &              source_and_target_mapping,
                         dealii::DoFHandler<dim> const &           target_dof_handler,
                         dealii::AffineConstraints<Number> const & target_constraints,
-                        dealii::Quadrature<dim> const &           quadrature)
+                        dealii::Quadrature<dim> const &           quadrature_dim)
 {
   // Check if the triangulations *might* be identical, assuming there is no adaptive refinement.
   dealii::Triangulation<dim> const & source_triangulation = source_dof_handler.get_triangulation();
@@ -165,28 +165,18 @@ assemble_projection_rhs(VectorType &                              system_rhs,
   dealii::FiniteElement<dim> const & source_fe = source_dof_handler.get_fe();
   dealii::FiniteElement<dim> const & target_fe = target_dof_handler.get_fe();
 
-  dealii::FEValues<dim> fe_values_source(source_and_target_mapping,
-                                         source_fe,
-                                         quadrature,
-                                         dealii::update_values);
-  dealii::FEValues<dim> fe_values_target(source_and_target_mapping,
-                                         target_fe,
-                                         quadrature,
-                                         dealii::update_values | dealii::update_JxW_values);
+  const dealii::Quadrature<1> & quadrature = quadrature_dim.get_tensor_basis()[0];
 
-  unsigned int const dofs_per_cell = target_fe.dofs_per_cell;
-  unsigned int const n_q_points    = quadrature.size();
+  dealii::FEEvaluation<dim, -1, 0, n_components, Number, dealii::VectorizedArray<Number, 1>>
+    fe_values_source(source_and_target_mapping, source_fe, quadrature, dealii::update_values);
+  dealii::FEEvaluation<dim, -1, 0, n_components, Number, dealii::VectorizedArray<Number, 1>>
+    fe_values_target(source_and_target_mapping,
+                     target_fe,
+                     quadrature,
+                     dealii::update_values | dealii::update_JxW_values);
 
-  std::vector<dealii::types::global_dof_index> dof_indices(dofs_per_cell);
-  std::vector<dealii::Tensor<1, dim>> vector_values_source(fe_values_source.n_quadrature_points);
-  std::vector<double>                 scalar_values_source(fe_values_source.n_quadrature_points);
-
-  dealii::FEValuesExtractors::Vector const vector(0);
-  dealii::FEValuesExtractors::Scalar const scalar(0);
-
-  dealii::Vector<double> cell_rhs(dofs_per_cell);
-
-  AssertThrow(n_components == dim or n_components == 1, dealii::ExcNotImplemented());
+  dealii::Vector<Number>                       cell_rhs(target_fe.dofs_per_cell);
+  std::vector<dealii::types::global_dof_index> dof_indices(target_fe.dofs_per_cell);
 
   for(const auto & cell_target : target_dof_handler.active_cell_iterators())
   {
@@ -196,28 +186,15 @@ assemble_projection_rhs(VectorType &                              system_rhs,
       fe_values_source.reinit(cell_source);
       fe_values_target.reinit(cell_target);
 
-      cell_rhs = 0.0;
+      fe_values_source.read_dof_values(source_vector);
+      fe_values_source.evaluate(dealii::EvaluationFlags::values);
+      for(const unsigned int q : fe_values_source.quadrature_point_indices())
+        fe_values_target.submit_value(fe_values_source.get_value(q), q);
 
-      if constexpr(n_components == dim)
-      {
-        fe_values_source[vector].get_function_values(source_vector, vector_values_source);
-
-        for(unsigned int q = 0; q < n_q_points; ++q)
-          for(unsigned int i = 0; i < dofs_per_cell; ++i)
-            cell_rhs[i] += vector_values_source[q] * fe_values_target[vector].value(i, q) *
-                           fe_values_target.JxW(q);
-      }
-      else
-      {
-        fe_values_source[scalar].get_function_values(source_vector, scalar_values_source);
-
-        for(unsigned int q = 0; q < n_q_points; ++q)
-          for(unsigned int i = 0; i < dofs_per_cell; ++i)
-            cell_rhs[i] += scalar_values_source[q] * fe_values_target[scalar].value(i, q) *
-                           fe_values_target.JxW(q);
-      }
-
-      // Assemble ignoring constraints as `dealii::MatrixFree` resolves constraints.
+      fe_values_target.integrate(dealii::EvaluationFlags::values);
+      for(unsigned int i = 0; i < cell_rhs.size(); ++i)
+        cell_rhs(fe_values_target.get_internal_dof_numbering()[i]) =
+          fe_values_target.begin_dof_values()[i][0];
       cell_target->get_dof_indices(dof_indices);
       target_constraints.distribute_local_to_global(cell_rhs, dof_indices, system_rhs);
     }


### PR DESCRIPTION
This speeds up the code for evaluating the projection rhs, as a follow-up to #23. Whereas the old code gave me the output
```
PROJECTION IN UNDEFORMED GRID

time: RPE reinit         1.3809e+00 s
global CG iterations in projection : 0
global CG iterations in projection : 0
global CG iterations in projection : 0
time: RPE interpolate    4.4375e-01 s
time: inverse mass rhs   2.7527e-02 s
time: inverse mass apply 2.9980e-02 s
time: RPE reinit         8.1704e-01 s
global CG iterations in projection : 0
time: RPE interpolate    3.3744e-02 s
time: inverse mass rhs   3.2282e-03 s
time: inverse mass apply 2.3757e-03 s

VELOCITY PROJECTION IN DEFORMED GRID

global CG iterations in projection : 42
global CG iterations in projection : 42
global CG iterations in projection : 42
time: RPE interpolate    0.0000e+00 s
time: inverse mass rhs   7.3551e+01 s
time: inverse mass apply 4.6531e+00 s
Writing restart vectors to .vtu files
Writing restart vectors to .vtu files
```
with the new code I instead get
```
PROJECTION IN UNDEFORMED GRID

time: RPE reinit         1.4156e+00 s
global CG iterations in projection : 0
global CG iterations in projection : 0
global CG iterations in projection : 0
time: RPE interpolate    4.5391e-01 s
time: inverse mass rhs   3.6740e-02 s
time: inverse mass apply 3.3868e-02 s
time: RPE reinit         8.1609e-01 s
global CG iterations in projection : 0
time: RPE interpolate    3.5363e-02 s
time: inverse mass rhs   3.2546e-03 s
time: inverse mass apply 2.6645e-03 s

VELOCITY PROJECTION IN DEFORMED GRID

global CG iterations in projection : 42
global CG iterations in projection : 42
global CG iterations in projection : 42
time: RPE interpolate    0.0000e+00 s
time: inverse mass rhs   3.1229e-01 s
time: inverse mass apply 5.8068e+00 s
Writing restart vectors to .vtu files
Writing restart vectors to .vtu files
```
for a medium-sized problem on a laptop. Note the reduction in run time from 73.55 seconds to 0.312 seconds.