### PR TITLE
iNS restart: fix fast path for HDIV and matching grids

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1397,9 +1397,8 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
         checkpoint_triangulation->n_global_levels() == triangulation.n_global_levels() and
         checkpoint_triangulation->n_global_active_cells() == triangulation.n_global_active_cells();
 
-      if(false) // spatial_resolution_identical == true)
+      if(spatial_resolution_identical == true)
       {
-        // TODO: this is failing for high numbers of MPI ranks.
         this->pcout << "\n"
                     << "USING IDENTICAL GRID\n\n";
 
@@ -1432,7 +1431,7 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
                       dealii::ExcMessage("Combination of manifolds and grid-to-grid projection "
                                          "in unmapped grid at restart not supported."));
 
-          // Create dummy linear mapping since we have no mapping serialized to restore.
+          // Create dummy linear mapping for projection on undeformed grid.
           std::shared_ptr<dealii::Mapping<dim>> default_mapping;
           GridUtilities::create_mapping(default_mapping,
                                         get_element_type(triangulation),
@@ -1464,11 +1463,17 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
             target_dof_handlers,
             *matrix_free,
             target_vectors_per_dof_handler,
-            projection_data);
+            projection_data,
+            {1} /* dof_index */,
+            {1} /* quad_index */);
 
           // Restore the mapping in `MatrixFree` to continue with the requested mapping after
           // restart.
           matrix_free_mutable->update_mapping(*this->get_mapping());
+
+          // Set pointers to pressure vectors for plotting.
+          checkpoint_vectors[1 /* pressure */]      = source_vectors_per_dof_handler[0];
+          checkpoint_dof_handlers[1 /* pressure */] = source_dof_handlers[0];
         }
       }
       else

--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -454,8 +454,8 @@ project_vectors(
 
 /**
  * Utility function to perform matrix-free grid-to-grid projection. We assume we only have a single
- * `dealii::FiniteElement` per `dealii::DoFHandler`. This function requires a suitable `MatrixFree`
- * object.
+ * `dealii::FiniteElement` per `dealii::DoFHandler`. This function requires a `MatrixFree` object,
+ * that contains the `DoFHandler` and a suitable integration rule at the specified indices.
  */
 template<int dim, typename Number, typename VectorType>
 void
@@ -466,7 +466,9 @@ do_grid_to_grid_projection(
   std::vector<dealii::DoFHandler<dim> const *> const & target_dof_handlers,
   dealii::MatrixFree<dim, Number, dealii::VectorizedArray<Number>> const & target_matrix_free,
   std::vector<std::vector<VectorType *>> & target_vectors_per_dof_handler,
-  GridToGridProjectionData<dim> const &    data)
+  GridToGridProjectionData<dim> const &    data,
+  std::vector<unsigned int> const &        dof_index_per_dof_handler  = {},
+  std::vector<unsigned int> const &        quad_index_per_dof_handler = {})
 {
   // Check input dimensions.
   AssertThrow(source_vectors_per_dof_handler.size() == source_dof_handlers.size(),
@@ -485,10 +487,21 @@ do_grid_to_grid_projection(
                   target_vectors_per_dof_handler.at(i).size(),
                 dealii::ExcMessage("Vectors of source and target vectors need to have same size."));
   }
+  AssertThrow(dof_index_per_dof_handler.size() == target_dof_handlers.size() or
+                dof_index_per_dof_handler.size() == 0,
+              dealii::ExcMessage("Provide DoF indices matching MatrixFree or none."));
+  AssertThrow(quad_index_per_dof_handler.size() == target_dof_handlers.size() or
+                quad_index_per_dof_handler.size() == 0,
+              dealii::ExcMessage("Provide quadrature indices matching MatrixFree or none."));
 
   // Project vectors per `dealii::DoFHandler`.
   for(unsigned int i = 0; i < target_dof_handlers.size(); ++i)
   {
+    unsigned int const dof_index =
+      dof_index_per_dof_handler.size() == 0 ? i : dof_index_per_dof_handler[i];
+    unsigned int const quad_index =
+      quad_index_per_dof_handler.size() == 0 ? i : quad_index_per_dof_handler[i];
+
     unsigned int const n_components = target_dof_handlers[i]->get_fe().n_components();
     if(n_components == 1)
     {
@@ -498,8 +511,8 @@ do_grid_to_grid_projection(
         source_vectors_per_dof_handler.at(i),
         target_matrix_free,
         target_vectors_per_dof_handler.at(i),
-        i /* dof_index */,
-        i /* quad_index */,
+        dof_index,
+        quad_index,
         data);
     }
     else if(n_components == dim)
@@ -510,8 +523,8 @@ do_grid_to_grid_projection(
         source_vectors_per_dof_handler.at(i),
         target_matrix_free,
         target_vectors_per_dof_handler.at(i),
-        i /* dof_index */,
-        i /* quad_index */,
+        dof_index,
+        quad_index,
         data);
     }
     else if(n_components == dim + 2)
@@ -522,8 +535,8 @@ do_grid_to_grid_projection(
         source_vectors_per_dof_handler.at(i),
         target_matrix_free,
         target_vectors_per_dof_handler.at(i),
-        i /* dof_index */,
-        i /* quad_index */,
+        dof_index,
+        quad_index,
         data);
     }
     else


### PR DESCRIPTION
**fast** path (same grid, different polynomial degree):
- project velocity to intermediate space (`FE_DQG_ArbitraryNodes`) via inverse diagonal solve
- project pressure to final space directly since it is `FE_DGQ` -> one can use the DoFs on the deformedgrid directly
- velocity: use mapped DoFs to interpolate in deformed grid, avoid RPE, project onto `HDIV` space

**slow** path (different grids):
- project velocity onto new grid in undeformed reference configuration to intermediate space (`FE_DQG_ArbitraryNodes`)
- (apply mapping)
- project velocity and pressure in deformed configuration to target spaces, but also avoiding RPE

so we can avoid a mass matrix solve for the velocity space and searching for the points via RPE (in the undeformed grid), which uses the fast matrix-free inverse anyways ... so I think robustness is the same, but its a bit faster.