### PR TITLE
Fix compilation of 'curl' with current deal.II version

### DIFF
--- a/include/exadg/operators/navier_stokes_calculators.cpp
+++ b/include/exadg/operators/navier_stokes_calculators.cpp
@@ -245,16 +245,17 @@ VorticityCalculator<dim, Number>::cell_loop(
 
     for(unsigned int q = 0; q < integrator.n_q_points; ++q)
     {
-      dealii::Tensor<1, number_vorticity_components, dealii::VectorizedArray<Number>> omega =
-        integrator.get_curl(q);
+      auto const omega = integrator.get_curl(q);
 
       // omega_vector is a vector with dim components
       // for dim=3: omega_vector[i] = omega[i], i=1,...,dim
       // for dim=2: omega_vector[0] = omega,
       //            omega_vector[1] = 0
       vector omega_vector;
-      for(unsigned int d = 0; d < number_vorticity_components; ++d)
-        omega_vector[d] = omega[d];
+      if constexpr(dim == 3)
+        omega_vector = omega;
+      else
+        omega_vector[0] = omega;
 
       integrator.submit_value(omega_vector, q);
     }

--- a/include/exadg/postprocessor/kinetic_energy_calculation.cpp
+++ b/include/exadg/postprocessor/kinetic_energy_calculation.cpp
@@ -187,7 +187,7 @@ KineticEnergyCalculator<dim, Number>::cell_loop(
                          dealii::make_vectorized_array<Number>(this->data.viscosity) *
                          scalar_product(velocity_gradient, velocity_gradient);
 
-      dealii::Tensor<1, number_vorticity_components, scalar> omega = fe_eval.get_curl(q);
+      auto const omega = fe_eval.get_curl(q);
 
       scalar norm_omega = omega * omega;
 


### PR DESCRIPTION
This PR fixes the changed interface from https://github.com/dealii/dealii/pull/19482, which makes the `curl` in 2D a scalar rather than a vector.