### PR TITLE
Implement better data locality order with flux buffer.

### DIFF
--- a/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics_homogeneous.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics_homogeneous.cpp
@@ -747,7 +747,8 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::print_headline(
   std::ofstream &    f,
   unsigned int const number_of_samples) const
 {
-  f << "number of samples: N = " << number_of_samples << std::endl;
+  f << "number of samples: N = " << number_of_samples << " representing a time span of "
+    << accumulated_time << std::endl;
 }
 
 void
@@ -817,13 +818,13 @@ apply_matrix_vector_vect_eo(const VectorizedArray<Number> * matrix,
 
 template<int dim, typename Number>
 void
-read_rt_cell_values(const unsigned int                                     degree_normal,
-                    const Number *                                         src_vector,
-                    const dealii::AlignedVector<VectorizedArray<Number>> & matrix_n,
-                    const dealii::AlignedVector<VectorizedArray<Number>> & matrix_t,
-                    const dealii::ndarray<unsigned int, 2 * dim + 1> &     dof_indices,
-                    std::vector<Number> &                                  tmp_array,
-                    std::vector<Tensor<1, dim, Number>> &                  out)
+read_rt_cell_values(const unsigned int                                             degree_normal,
+                    const Number *                                                 src_vector,
+                    const dealii::AlignedVector<dealii::VectorizedArray<Number>> & matrix_n,
+                    const dealii::AlignedVector<dealii::VectorizedArray<Number>> & matrix_t,
+                    const dealii::ndarray<unsigned int, 2 * dim + 1> &             dof_indices,
+                    std::vector<Number> &                                          tmp_array,
+                    std::vector<dealii::Tensor<1, dim, Number>> &                  out)
 {
   const unsigned int n_t                = degree_normal;
   const unsigned int n_n                = n_t + 1;
@@ -955,6 +956,7 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
   double const       time_step_size_for_sampling)
 {
   dealii::Timer time;
+  using VectorizedArrayType = dealii::VectorizedArray<Number>;
   // increment number of samples
   number_of_samples++;
   accumulated_time += time_step_size_for_sampling;
@@ -964,12 +966,12 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
   if(rt_operator != nullptr)
   {
     velocity.update_ghost_values();
-    dealii::AlignedVector<Tensor<1, dim, VectorizedArray<Number>>> eval_field(
+    dealii::AlignedVector<dealii::Tensor<1, dim, VectorizedArrayType>> eval_field(
       evaluated_dg_values_on_cells.size(1));
     for(unsigned int i = 0; i < list_of_cells_to_evaluate.size(); ++i)
     {
       rt_operator->evaluate_field(velocity, list_of_cells_to_evaluate[i], eval_field);
-      std::array<unsigned int, VectorizedArray<Number>::size()> store_indices;
+      std::array<unsigned int, VectorizedArrayType::size()> store_indices;
       for(unsigned int j = 0; j < store_indices.size(); ++j)
         store_indices[j] = j * dim * eval_field.size();
       dealii::vectorized_transpose_and_store(
@@ -977,7 +979,7 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
         dim * eval_field.size(),
         &eval_field[0][0],
         store_indices.data(),
-        &evaluated_dg_values_on_cells(i * VectorizedArray<Number>::size(), 0)[0]);
+        &evaluated_dg_values_on_cells(i * VectorizedArrayType::size(), 0)[0]);
     }
   }
   else if(dof_indices_on_cell.empty())
@@ -1023,12 +1025,12 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
 
   std::vector<dealii::Tensor<1, dim, Number>> velocity_dgq_on_cell(
     jacobians_at_nodal_points.size(1));
-  std::vector<Number>                                                  tmp_array;
-  std::array<dealii::ndarray<VectorizedArray<Number>, 2, dim - 1>, 20> shapes_2d;
+  std::vector<Number>                                              tmp_array;
+  std::array<dealii::ndarray<VectorizedArrayType, 2, dim - 1>, 20> shapes_2d;
 
   const unsigned int n_points_in_plane = dealii::Utilities::pow(n_q_points_1d, dim - 1);
-  std::vector<Tensor<1, dim, Number>>          cell_averaged_velocity;
-  std::vector<SymmetricTensor<2, dim, Number>> cell_averaged_reynolds;
+  std::vector<dealii::Tensor<1, dim, Number>>          cell_averaged_velocity;
+  std::vector<dealii::SymmetricTensor<2, dim, Number>> cell_averaged_reynolds;
 
   if(rt_operator == nullptr)
     velocity.update_ghost_values();
@@ -1080,7 +1082,8 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
           has_skin_friction_quantity = true;
 
       AssertThrow(has_skin_friction_quantity,
-                  ExcMessage("Dissipation requires QuantitySkinFriction to provide viscosity."));
+                  dealii::ExcMessage(
+                    "Dissipation requires QuantitySkinFriction to provide viscosity."));
     }
 
 
@@ -1095,7 +1098,7 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
     {
       for(auto const & [cell, point_list] : cells_and_ref_points[index])
       {
-        Tensor<1, dim, Number> * eval_ptr = nullptr;
+        dealii::Tensor<1, dim, Number> * eval_ptr = nullptr;
         if(rt_operator == nullptr)
         {
           const std::array<unsigned int, 2 * dim + 1> cell_indices =
@@ -1112,17 +1115,21 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
                                 velocity_dgq_on_cell);
             for(unsigned int q = 0; q < velocity_dgq_on_cell.size(); ++q)
             {
-              const Tensor<2, dim> jac = jacobians_at_nodal_points(counter_all_cells, q);
-              velocity_dgq_on_cell[q]  = (jac * velocity_dgq_on_cell[q]) / determinant(jac);
+              const dealii::Tensor<2, dim> jac = jacobians_at_nodal_points(counter_all_cells, q);
+              velocity_dgq_on_cell[q]          = (jac * velocity_dgq_on_cell[q]) / determinant(jac);
             }
           }
           else
             for(unsigned int c = 0; c < dim; ++c)
             {
-              internal::
-                EvaluatorTensorProduct<internal::evaluate_evenodd, dim, 0, 0, Number, Number>
-                  eval(
-                    shape_values_eo_dgq.data(), nullptr, nullptr, fe_u.degree + 1, fe_u.degree + 1);
+              dealii::internal::EvaluatorTensorProduct<dealii::internal::evaluate_evenodd,
+                                                       dim,
+                                                       0,
+                                                       0,
+                                                       Number,
+                                                       Number>
+                eval(
+                  shape_values_eo_dgq.data(), nullptr, nullptr, fe_u.degree + 1, fe_u.degree + 1);
               eval.template values<0, true, false>(velocity.begin() + cell_indices[0] +
                                                      c * velocity_dgq_on_cell.size(),
                                                    tmp_array.data());
@@ -1165,13 +1172,13 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
         // directions are hardcoded, so we can only support the last direction
         // here
         AssertThrow(averaging_direction == dim - 1, dealii::ExcNotImplemented());
-        const unsigned int n_lanes  = VectorizedArray<Number>::size();
+        const unsigned int n_lanes  = VectorizedArrayType::size();
         const unsigned int n_points = point_list.size();
         const unsigned int n_chunks = (n_points + n_lanes - 1) / n_lanes;
         for(unsigned int p1_v = 0; p1_v < n_chunks; ++p1_v)
         {
-          dealii::Point<dim - 1, VectorizedArray<Number>> point_on_line;
-          Tensor<2, dim, VectorizedArray<Number>>         inv_jac;
+          dealii::Point<dim - 1, VectorizedArrayType> point_on_line;
+          dealii::Tensor<2, dim, VectorizedArrayType> inv_jac;
           for(unsigned int d = 0; d < dim; ++d)
             inv_jac[d][d] = 1.0;
           for(unsigned int p1 = p1_v * n_lanes, v = 0;
@@ -1181,15 +1188,15 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
             for(unsigned int d = 0, c = 0; d < dim; ++d)
               if(d != averaging_direction)
                 point_on_line[c++][v] = point_list[p1].second[d];
-            Tensor<2, dim> const inv_jac_v = inverse_jacobians_on_lines[counter_line++];
+            dealii::Tensor<2, dim> const inv_jac_v = inverse_jacobians_on_lines[counter_line++];
             for(unsigned int d = 0; d < dim; ++d)
               for(unsigned int e = 0; e < dim; ++e)
                 inv_jac[d][e][v] = inv_jac_v[d][e];
           }
           // bool                                    need_skin_friction = false;
 
-          Tensor<1, dim, VectorizedArray<Number>> normal;
-          Tensor<1, dim, VectorizedArray<Number>> tangent;
+          dealii::Tensor<1, dim, VectorizedArrayType> normal;
+          dealii::Tensor<1, dim, VectorizedArrayType> tangent;
 
           Number viscosity = 0.0;
           if(need_skin_friction || need_dissipation)
@@ -1199,10 +1206,10 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
               if(quantity->type == QuantityType::SkinFriction)
               {
                 auto q = std::dynamic_pointer_cast<QuantitySkinFriction<dim>>(quantity);
-                AssertThrow(q, ExcInternalError());
+                AssertThrow(q, dealii::ExcInternalError());
 
-                Tensor<2, dim, VectorizedArray<Number>> jac = invert(transpose(inv_jac));
-                tangent                                     = jac * q->tangent_vector;
+                dealii::Tensor<2, dim, VectorizedArrayType> jac = invert(transpose(inv_jac));
+                tangent                                         = jac * q->tangent_vector;
                 tangent /= tangent.norm();
 
                 if(averaging_direction == 2)
@@ -1211,42 +1218,44 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
                   normal[1] = -tangent[0];
                 }
                 else
-                  AssertThrow(false, ExcNotImplemented());
+                  AssertThrow(false, dealii::ExcNotImplemented());
 
                 viscosity           = q->viscosity;
                 found_skin_friction = true;
               }
             AssertThrow(found_skin_friction,
-                        ExcMessage("Dissipation/SkinFriction requires QuantitySkinFriction"));
+                        dealii::ExcMessage(
+                          "Dissipation/SkinFriction requires QuantitySkinFriction"));
           }
 
 
-          VectorizedArray<Number> const det =
+          VectorizedArrayType const det =
             1.0 / std::abs(inv_jac[averaging_direction][averaging_direction]);
           dealii::internal::compute_values_of_array(shapes_2d.data(),
                                                     polynomials_nodal,
                                                     point_on_line);
 
-          const VectorizedArray<Number>                    length = det;
-          Tensor<1, dim, VectorizedArray<Number>>          vel;
-          SymmetricTensor<2, dim, VectorizedArray<Number>> reynolds;
-          VectorizedArray<Number>                          skin_friction = 0;
-          VectorizedArray<Number>                          dissipation   = 0.0;
+          const VectorizedArrayType                            length = det;
+          dealii::Tensor<1, dim, VectorizedArrayType>          vel;
+          dealii::SymmetricTensor<2, dim, VectorizedArrayType> reynolds;
+          VectorizedArrayType                                  skin_friction = 0;
+          VectorizedArrayType                                  dissipation   = 0.0;
           if constexpr(!evaluate_averaging_by_tensor_product)
           {
-            Tensor<1, dim, VectorizedArray<Number>> velocity;
-            Tensor<2, dim, VectorizedArray<Number>> velocity_gradient;
+            dealii::Tensor<1, dim, VectorizedArrayType> velocity;
+            dealii::Tensor<2, dim, VectorizedArrayType> velocity_gradient;
             for(unsigned int q1 = 0; q1 < n_q_points_1d; ++q1)
             {
-              VectorizedArray<Number> const JxW = det * gauss_1d.weight(q1);
+              VectorizedArrayType const JxW = det * gauss_1d.weight(q1);
               if(need_velocity_gradient)
               {
-                auto const val_grad = internal::evaluate_tensor_product_value_and_gradient_shapes<
-                  dim - 1,
-                  Tensor<1, dim, Number>,
-                  VectorizedArray<Number>>(shapes_2d.data(),
-                                           polynomials_nodal.size(),
-                                           eval_ptr + q1 * n_points_in_plane);
+                auto const val_grad =
+                  dealii::internal::evaluate_tensor_product_value_and_gradient_shapes<
+                    dim - 1,
+                    dealii::Tensor<1, dim, Number>,
+                    VectorizedArrayType>(shapes_2d.data(),
+                                         polynomials_nodal.size(),
+                                         eval_ptr + q1 * n_points_in_plane);
                 velocity = val_grad[dim - 1];
                 for(unsigned int d = 0; d < dim; ++d)
                 {
@@ -1257,7 +1266,7 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
 
                 if(need_dissipation)
                 {
-                  VectorizedArray<Number> epsilon_q = 0.0;
+                  VectorizedArrayType epsilon_q = 0.0;
                   for(unsigned int i = 0; i < dim; ++i)
                     for(unsigned int j = 0; j < dim; ++j)
                       epsilon_q += velocity_gradient[i][j] * velocity_gradient[i][j];
@@ -1273,10 +1282,12 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
                 }
               }
               else
-                velocity = internal::evaluate_tensor_product_value_shapes<dim - 1,
-                                                                          Tensor<1, dim, Number>,
-                                                                          VectorizedArray<Number>>(
-                  shapes_2d.data(), polynomials_nodal.size(), eval_ptr + q1 * n_points_in_plane);
+                velocity = dealii::internal::evaluate_tensor_product_value_shapes<
+                  dim - 1,
+                  dealii::Tensor<1, dim, Number>,
+                  VectorizedArrayType>(shapes_2d.data(),
+                                       polynomials_nodal.size(),
+                                       eval_ptr + q1 * n_points_in_plane);
 
               for(const std::shared_ptr<Quantity> & quantity : line.quantities)
               {
@@ -1304,14 +1315,15 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
           {
             if(need_velocity_gradient)
             {
-              auto const val_grad = internal::evaluate_tensor_product_value_and_gradient_shapes<
-                dim - 1,
-                Tensor<1, dim, Number>,
-                VectorizedArray<Number>>(shapes_2d.data(),
-                                         polynomials_nodal.size(),
-                                         cell_averaged_velocity.data());
+              auto const val_grad =
+                dealii::internal::evaluate_tensor_product_value_and_gradient_shapes<
+                  dim - 1,
+                  dealii::Tensor<1, dim, Number>,
+                  VectorizedArrayType>(shapes_2d.data(),
+                                       polynomials_nodal.size(),
+                                       cell_averaged_velocity.data());
               vel = val_grad[dim - 1];
-              Tensor<2, dim, VectorizedArray<Number>> grad;
+              dealii::Tensor<2, dim, VectorizedArrayType> grad;
               for(unsigned int d = 0; d < dim; ++d)
               {
                 for(unsigned int e = 0; e < dim - 1; ++e)
@@ -1326,15 +1338,18 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
               }
             }
             else
-              vel = internal::evaluate_tensor_product_value_shapes<dim - 1,
-                                                                   Tensor<1, dim, Number>,
-                                                                   VectorizedArray<Number>>(
-                shapes_2d.data(), polynomials_nodal.size(), cell_averaged_velocity.data());
-            reynolds =
-              internal::evaluate_tensor_product_value_shapes<dim - 1,
-                                                             SymmetricTensor<2, dim, Number>,
-                                                             VectorizedArray<Number>>(
-                shapes_2d.data(), polynomials_nodal.size(), cell_averaged_reynolds.data());
+              vel = dealii::internal::evaluate_tensor_product_value_shapes<
+                dim - 1,
+                dealii::Tensor<1, dim, Number>,
+                VectorizedArrayType>(shapes_2d.data(),
+                                     polynomials_nodal.size(),
+                                     cell_averaged_velocity.data());
+            reynolds = dealii::internal::evaluate_tensor_product_value_shapes<
+              dim - 1,
+              dealii::SymmetricTensor<2, dim, Number>,
+              VectorizedArrayType>(shapes_2d.data(),
+                                   polynomials_nodal.size(),
+                                   cell_averaged_reynolds.data());
           }
 
           for(unsigned int p1 = p1_v * n_lanes, v = 0;
@@ -1365,7 +1380,7 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
               else if(quantity->type == QuantityType::Dissipation)
               {
                 dissipation_local[offset_arrays + p] += dissipation[v];
-                VectorizedArray<Number> local_he =
+                VectorizedArrayType local_he =
                   std::pow(Number(1.0) / std::abs(determinant(inv_jac)), Number(1.0 / 3.0));
 
                 grid_size_local[offset_arrays + p] += local_he[v] * det[v];
@@ -1826,8 +1841,8 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_write_output() const
       ++line_iterator;
     }
     const_cast<double &>(time_all) += time.wall_time();
-    std::cout << "Accumulated time = " << accumulated_time << " output line stats t = " << time_all
-              << " s" << std::endl;
+    std::cout << "Accumulated " << number_of_samples
+              << " samples on lines in a compute time of t = " << time_all << " s" << std::endl;
   }
 }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/extruded_mapping_info.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/extruded_mapping_info.h
@@ -87,103 +87,184 @@ convert_map_to_range_list(const unsigned int                                    
   }
 }
 
+
+
+template<std::size_t dim>
+void
+group_cells_by_left_neighbors(
+  const std::array<int, dim> &                               lexicographic_index,
+  const typename dealii::Triangulation<dim>::cell_iterator & cell,
+  std::array<std::vector<std::pair<std::array<int, dim>,
+                                   typename dealii::Triangulation<dim>::active_cell_iterator>>,
+             8> &                                            cells_per_neighbor_value)
+{
+  if(cell->is_active() && cell->is_locally_owned())
+  {
+    unsigned int boundary_type = 0;
+    for(unsigned int d = 0; d < dim; ++d)
+      if(cell->at_boundary(2 * d) || cell->neighbor(2 * d)->subdomain_id() != cell->subdomain_id())
+      {
+        boundary_type += dealii::Utilities::pow(2, d);
+      }
+    cells_per_neighbor_value[boundary_type].emplace_back(lexicographic_index, cell);
+  }
+  else if(cell->n_children() == dealii::Utilities::pow(2, dim))
+    for(unsigned int child = 0, d2 = 0; d2 < (dim > 2 ? 2 : 1); ++d2)
+      for(unsigned int d1 = 0; d1 < (dim > 1 ? 2 : 1); ++d1)
+        for(unsigned int d0 = 0; d0 < 2; ++d0, ++child)
+        {
+          std::array<int, dim> child_lexicographic;
+          child_lexicographic[dim - 1] = lexicographic_index[dim - 1] * 2 + d0;
+          if constexpr(dim > 1)
+            child_lexicographic[dim - 2] = lexicographic_index[dim - 2] * 2 + d1;
+          if constexpr(dim > 2)
+            child_lexicographic[dim - 3] = lexicographic_index[dim - 3] * 2 + d2;
+          group_cells_by_left_neighbors(child_lexicographic,
+                                        cell->child(child),
+                                        cells_per_neighbor_value);
+        }
+  else
+    AssertThrow(false, dealii::ExcMessage("Only hypercube elements allowed for this code path"));
+}
+
+
+
+// Create categories of cells to ensure optimal use of the face flux buffer
+// in the context of vectorization: we would like to place cells at the
+// boundary or adjacent to remote processes (requiring different algorithms
+// for the face data) in a lower category such that they get processed
+// first. The assignment aims for having as few cells as possible in batches
+// that are more expensive, i.e., to have cells placed together that have
+// the same faces with the increased cost
 template<int dim>
 std::vector<unsigned int>
 compute_vectorization_category(const dealii::Triangulation<dim> & tria)
 {
-  std::vector<unsigned int> cell_vectorization_category;
-  if(tria.n_levels() > 2)
-  {
-    cell_vectorization_category.resize(tria.n_active_cells(),
-                                       dealii::numbers::invalid_unsigned_int);
-    unsigned int                             next_category = 0;
-    std::array<std::vector<unsigned int>, 8> next_cells;
-    std::vector<unsigned int>                sorted_next_cells;
-    for(const auto & grandparent : tria.cell_iterators_on_level(tria.n_levels() - 3))
-      if(grandparent->has_children())
-      {
-        for(auto & entry : next_cells)
-          entry.clear();
-        for(unsigned int c0 = 0; c0 < grandparent->n_children(); ++c0)
-        {
-          const auto parent = grandparent->child(c0);
-          if(parent->has_children())
-            for(unsigned int c = 0; c < parent->n_children(); ++c)
-            {
-              const auto cell = parent->child(c);
-              Assert(cell->is_active(), dealii::ExcInternalError());
-              if(cell->is_locally_owned())
-              {
-                unsigned int boundary_type = 0;
-                for(unsigned int d = 0; d < dim; ++d)
-                  if(cell->at_boundary(2 * d) ||
-                     cell->neighbor(2 * d)->subdomain_id() != cell->subdomain_id())
-                  {
-                    boundary_type += dealii::Utilities::pow(2, d);
-                  }
-                next_cells[boundary_type].push_back(cell->active_cell_index());
-              }
-            }
-        }
-        unsigned int n_cells = 0;
-        for(const std::vector<unsigned int> & cells : next_cells)
-          n_cells += cells.size();
-        sorted_next_cells.clear();
-        sorted_next_cells.insert(sorted_next_cells.end(),
-                                 next_cells[7].begin(),
-                                 next_cells[7].end());
-        sorted_next_cells.insert(sorted_next_cells.end(),
-                                 next_cells[6].begin(),
-                                 next_cells[6].end());
-        sorted_next_cells.insert(sorted_next_cells.end(),
-                                 next_cells[5].begin(),
-                                 next_cells[5].end());
-        unsigned int count_4 = 0, count_2 = 0, count_1 = 0;
-        while(sorted_next_cells.size() % 16 != 0 && count_4 < next_cells[4].size())
-        {
-          sorted_next_cells.push_back(next_cells[4][count_4]);
-          ++count_4;
-        }
-        sorted_next_cells.insert(sorted_next_cells.end(),
-                                 next_cells[3].begin(),
-                                 next_cells[3].end());
-        while(sorted_next_cells.size() % 16 != 0 && count_4 < next_cells[4].size())
-        {
-          sorted_next_cells.push_back(next_cells[4][count_4]);
-          ++count_4;
-        }
-        while(sorted_next_cells.size() % 16 != 0 && count_2 < next_cells[2].size())
-        {
-          sorted_next_cells.push_back(next_cells[2][count_2]);
-          ++count_2;
-        }
-        while(sorted_next_cells.size() % 16 != 0 && count_1 < next_cells[1].size())
-        {
-          sorted_next_cells.push_back(next_cells[1][count_1]);
-          ++count_1;
-        }
-        // possibly move some insertions of category 0 in between to fill
-        // up and avoid further exchange steps
-        sorted_next_cells.insert(sorted_next_cells.end(),
-                                 next_cells[1].begin() + count_1,
-                                 next_cells[1].end());
-        sorted_next_cells.insert(sorted_next_cells.end(),
-                                 next_cells[2].begin() + count_2,
-                                 next_cells[2].end());
-        sorted_next_cells.insert(sorted_next_cells.end(),
-                                 next_cells[4].begin() + count_4,
-                                 next_cells[4].end());
-        sorted_next_cells.insert(sorted_next_cells.end(),
-                                 next_cells[0].begin(),
-                                 next_cells[0].end());
-        AssertThrow(sorted_next_cells.size() == n_cells,
-                    dealii::ExcDimensionMismatch(sorted_next_cells.size(), n_cells));
+  std::vector<unsigned int> cell_vectorization_category(tria.n_active_cells(),
+                                                        dealii::numbers::invalid_unsigned_int);
 
-        for(unsigned int i = 0; i < n_cells; ++next_category)
-          for(unsigned int j = 0; j < 16 && i < n_cells; ++j, ++i)
-            cell_vectorization_category[sorted_next_cells[i]] = next_category;
-      }
+  unsigned int n_owned_cells = 0;
+  for(const auto & cell : tria.active_cell_iterators())
+    if(cell->is_locally_owned())
+      ++n_owned_cells;
+
+  unsigned int category_counter = 0;
+
+  // Store:
+  //   - lexicographic coordinates (for ordering) - note that the z index
+  //     comes first to allow standard sorting, this impacts the use of the
+  //     index below
+  //   - corresponding active cell iterator
+  using CellLexEntry =
+    std::pair<std::array<int, dim>, typename dealii::Triangulation<dim>::active_cell_iterator>;
+
+  // Partition cells according to neighbor configuration.
+  // Index meaning:
+  //   0 = fully interior cells (all left neighbors treated in the same code,
+  //       providing opportunity to use a flux buffer from right faces)
+  //   1,2,... = cells touching specific subdomain boundary configurations or
+  //             the physical boundary
+  std::array<std::vector<CellLexEntry>, 8> cells_per_neighbor_value;
+
+  // Limit the number of levels we use for the lexicographic traversal,
+  // avoiding bad cache usage. For low degrees, it might actually make sense
+  // to allow for one more level, but in general the utilization with 8^dim
+  // cells is already very good in this case and improvements are rather
+  // minor from allowing up to 16^dim cells.
+  unsigned int blocking_level = 0;
+  if(tria.n_levels() > 4)
+    blocking_level = tria.n_levels() - 4;
+
+  for(const auto & cell : tria.cell_iterators_on_level(blocking_level))
+  {
+    // Group cells by their left neighbor, and within each group create
+    // a lexicographic ordering
+    for(auto & local_vector : cells_per_neighbor_value)
+      local_vector.clear();
+
+    // Recursively group descendant cells by left-neighbor pattern and
+    // collect lexicographic positions.
+    group_cells_by_left_neighbors(std::array<int, dim>{}, cell, cells_per_neighbor_value);
+
+    // Sort each group lexicographically
+    for(auto & local_vector : cells_per_neighbor_value)
+      std::sort(local_vector.begin(), local_vector.end());
+
+    // First do xy base layer with z faces at boundary and the category of
+    // z > 0, x=y=0
+    for(unsigned int neighbor_id = 7; neighbor_id > 2; --neighbor_id)
+      for(auto & entry : cells_per_neighbor_value[neighbor_id])
+        cell_vectorization_category[entry.second->active_cell_index()] = category_counter++;
+
+    // Then proceed layer by layer, including some blocking for cells
+    // along the y/z faces and the interior to increase the data locality;
+    // the SIMD width determines preferred category block size
+    constexpr unsigned int n_lanes = dealii::VectorizedArray<float>::size();
+    std::array<typename std::vector<CellLexEntry>::iterator, 3> lex_ptrs{
+      {cells_per_neighbor_value[0].begin(),
+       cells_per_neighbor_value[1].begin(),
+       cells_per_neighbor_value[2].begin()}};
+    const std::array<typename std::vector<CellLexEntry>::iterator, 3> lex_ends{
+      {cells_per_neighbor_value[0].end(),
+       cells_per_neighbor_value[1].end(),
+       cells_per_neighbor_value[2].end()}};
+
+    // First fill up the lanes with the previously accumulated info,
+    // making sure that the remaining parts also fit within the available
+    // lanes to ensure a good utilization
+    auto assign_category = [&](auto & it) {
+      cell_vectorization_category[it->second->active_cell_index()] = category_counter++;
+      ++it;
+    };
+
+    // Before proceeding with the next category, fill up with cells whose
+    // pattern should already be present in the same vectorization batch: we
+    // either had category 3 or some previous one; in either case, we should
+    // expect that categories 1 and 2 fit well; we first try to use cells of
+    // those categories until they are divisible by the SIMD length
+    // themselves, then we use some of the remaining cells
+    while(category_counter % n_lanes != 0)
+    {
+      if(lex_ptrs[2] != lex_ends[2] && (lex_ends[2] - lex_ptrs[2]) % n_lanes > 0)
+        assign_category(lex_ptrs[2]);
+      else if(lex_ptrs[1] != lex_ends[1] && (lex_ends[1] - lex_ptrs[1]) % n_lanes > 0)
+        assign_category(lex_ptrs[1]);
+      else if(lex_ptrs[2] != lex_ends[2])
+        assign_category(lex_ptrs[2]);
+      else if(lex_ptrs[1] != lex_ends[1])
+        assign_category(lex_ptrs[1]);
+      else if(lex_ptrs[0] != lex_ends[0])
+        assign_category(lex_ptrs[0]);
+      else
+        break;
+    }
+
+    // Then proceed layer by layer, always making sure that the interior
+    // part with index 0 (= all faces have a left neighbor and can use the
+    // flux buffer) comes after the other cells to not create bubbles
+    // without 'left' neighbor data accessible in flux buffer
+    while(lex_ptrs[0] != lex_ends[0])
+    {
+      int z_index = std::numeric_limits<int>::max();
+      if((lex_ends[0] - lex_ptrs[0]) >= n_lanes)
+        z_index = (lex_ptrs[0] + n_lanes)->first[0];
+      while(lex_ptrs[2] != lex_ends[2] && lex_ptrs[2]->first[0] <= z_index)
+        assign_category(lex_ptrs[2]);
+      while(lex_ptrs[2] != lex_ends[2] && category_counter % n_lanes != 0)
+        assign_category(lex_ptrs[2]);
+      while(lex_ptrs[1] != lex_ends[1] && lex_ptrs[1]->first[0] <= z_index)
+        assign_category(lex_ptrs[1]);
+      while(lex_ptrs[1] != lex_ends[1] && category_counter % n_lanes != 0)
+        assign_category(lex_ptrs[1]);
+      do
+        assign_category(lex_ptrs[0]);
+      while(lex_ptrs[0] != lex_ends[0] && category_counter % n_lanes != 0);
+    }
   }
+  // Final consistency check:
+  // every locally owned cell must have received exactly one category.
+  AssertThrow(category_counter == n_owned_cells,
+              dealii::ExcDimensionMismatch(category_counter, n_owned_cells));
   return cell_vectorization_category;
 }
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/extruded_mapping_info.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/extruded_mapping_info.h
@@ -89,6 +89,12 @@ convert_map_to_range_list(const unsigned int                                    
 
 
 
+// Our algorithm use the fluxes computed on the right face as input to the
+// left faces of the neighboring cell through a flux buffer. However, this can
+// only be done for faces that are locally owned and if the cell on the left
+// has already computed its right faces. We therefore try to set up an order
+// of cells that is beneficial according to this metric, which we achieve by a
+// local lexicographic ordering of the cells.
 template<std::size_t dim>
 void
 group_cells_by_left_neighbors(
@@ -100,6 +106,11 @@ group_cells_by_left_neighbors(
 {
   if(cell->is_active() && cell->is_locally_owned())
   {
+    // query the MPI ranks set by deal.II to see whether the neighbor cell is
+    // owned by another MPI process (given by hte subdomain_id of deal.II) or
+    // if we are at the boundary. In those cases, we need to compute the
+    // fluxes, so they are given separate type, which we then use to group
+    // cells further down
     unsigned int boundary_type = 0;
     for(unsigned int d = 0; d < dim; ++d)
       if(cell->at_boundary(2 * d) || cell->neighbor(2 * d)->subdomain_id() != cell->subdomain_id())
@@ -108,24 +119,32 @@ group_cells_by_left_neighbors(
       }
     cells_per_neighbor_value[boundary_type].emplace_back(lexicographic_index, cell);
   }
-  else if(cell->has_children() && cell->n_children() == dealii::Utilities::pow(2, dim))
-    for(unsigned int child = 0, d2 = 0; d2 < (dim > 2 ? 2 : 1); ++d2)
-      for(unsigned int d1 = 0; d1 < (dim > 1 ? 2 : 1); ++d1)
-        for(unsigned int d0 = 0; d0 < 2; ++d0, ++child)
-        {
-          std::array<int, dim> child_lexicographic;
-          child_lexicographic[dim - 1] = lexicographic_index[dim - 1] * 2 + d0;
-          if constexpr(dim > 1)
-            child_lexicographic[dim - 2] = lexicographic_index[dim - 2] * 2 + d1;
-          if constexpr(dim > 2)
-            child_lexicographic[dim - 3] = lexicographic_index[dim - 3] * 2 + d2;
-          group_cells_by_left_neighbors(child_lexicographic,
-                                        cell->child(child),
-                                        cells_per_neighbor_value);
-        }
-  else
-    AssertThrow(cell->has_children() == false,
+  else if(cell->has_children())
+  {
+    AssertThrow(cell->n_children() == dealii::Utilities::pow(2, dim) &&
+                cell->reference_cell().is_hyper_cube(),
                 dealii::ExcMessage("Only hypercube elements allowed for this code path"));
+
+    for(unsigned int child = 0; child < cell->n_children(); ++child)
+    {
+      std::array<int, dim> child_lexicographic;
+      // retrieve the lexicographic index from the linear index of cell
+      // children. Note that we switch the index to have the last index in
+      // the first index array because we later want to sort data
+      // lexicographically
+
+      for(unsigned int d = 0; d < dim; ++d)
+      {
+        // compute bitmask along current direction
+        const unsigned int bit           = (child >> d) & 1;
+        child_lexicographic[dim - 1 - d] = lexicographic_index[dim - 1 - d] * 2 + bit;
+      }
+
+      group_cells_by_left_neighbors(child_lexicographic,
+                                    cell->child(child),
+                                    cells_per_neighbor_value);
+    }
+  }
 }
 
 
@@ -167,11 +186,16 @@ compute_vectorization_category(const dealii::Triangulation<dim> & tria)
   //             the physical boundary
   std::array<std::vector<CellLexEntry>, 8> cells_per_neighbor_value;
 
-  // Limit the number of levels we use for the lexicographic traversal,
-  // avoiding bad cache usage. For low degrees, it might actually make sense
-  // to allow for one more level, but in general the utilization with 8^dim
-  // cells is already very good in this case and improvements are rather
-  // minor from allowing up to 16^dim cells.
+  // Limit the number of levels of cells that will be traversed
+  // lexicographically. This is because lexicographic ordering in the limit
+  // case leads to worse cache usage than a hierarchical (Morton-like)
+  // ordering, and the reason we do this is like the cache blocking strategies
+  // for finite differences, namely to switch to loop tiling. Using this
+  // setting will slightly reduce the ratio of faces that can use the flux
+  // buffer, but in comparison the cost is lower. For low degrees, it might
+  // make sense to allow for one more level, but in general the flux buffer
+  // utilization with 8^dim cells is already very good in this case and
+  // improvements are rather minor from allowing up to 16^dim cells.
   unsigned int blocking_level = 0;
   if(tria.n_levels() > 4)
     blocking_level = tria.n_levels() - 4;
@@ -211,8 +235,8 @@ compute_vectorization_category(const dealii::Triangulation<dim> & tria)
        cells_per_neighbor_value[2].end()}};
 
     // First fill up the lanes with the previously accumulated info,
-    // making sure that the remaining parts also fit within the available
-    // lanes to ensure a good utilization
+    // making sure that the remaining parts also fits within the available
+    // lanes to ensure a good utilization.
     auto assign_category = [&](auto & it) {
       cell_vectorization_category[it->second->active_cell_index()] = category_counter++;
       ++it;
@@ -223,7 +247,7 @@ compute_vectorization_category(const dealii::Triangulation<dim> & tria)
     // either had category 3 or some previous one; in either case, we should
     // expect that categories 1 and 2 fit well; we first try to use cells of
     // those categories until they are divisible by the SIMD length
-    // themselves, then we use some of the remaining cells
+    // themselves, then we use some of the remaining cells.
     while(category_counter % n_lanes != 0)
     {
       if(lex_ptrs[2] != lex_ends[2] && (lex_ends[2] - lex_ptrs[2]) % n_lanes > 0)

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/extruded_mapping_info.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/extruded_mapping_info.h
@@ -108,7 +108,7 @@ group_cells_by_left_neighbors(
       }
     cells_per_neighbor_value[boundary_type].emplace_back(lexicographic_index, cell);
   }
-  else if(cell->n_children() == dealii::Utilities::pow(2, dim))
+  else if(cell->has_children() && cell->n_children() == dealii::Utilities::pow(2, dim))
     for(unsigned int child = 0, d2 = 0; d2 < (dim > 2 ? 2 : 1); ++d2)
       for(unsigned int d1 = 0; d1 < (dim > 1 ? 2 : 1); ++d1)
         for(unsigned int d0 = 0; d0 < 2; ++d0, ++child)
@@ -124,7 +124,8 @@ group_cells_by_left_neighbors(
                                         cells_per_neighbor_value);
         }
   else
-    AssertThrow(false, dealii::ExcMessage("Only hypercube elements allowed for this code path"));
+    AssertThrow(cell->has_children() == false,
+                dealii::ExcMessage("Only hypercube elements allowed for this code path"));
 }
 
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
@@ -222,7 +222,7 @@ public:
     const FiniteElement<dim> &                       fe = dof_handler.get_fe();
     typename MatrixFree<dim, Number>::AdditionalData mf_data;
     mf_data.cell_vectorization_category          = cell_vectorization_category;
-    mf_data.cell_vectorization_categories_strict = true;
+    mf_data.cell_vectorization_categories_strict = false;
     mf_data.overlap_communication_computation    = false;
     mf_data.initialize_mapping                   = false;
     matrix_free.reinit(mapping, dof_handler, constraints, quadrature, mf_data);
@@ -1193,7 +1193,7 @@ public:
     const FiniteElement<dim> &                       fe = dof_handler.get_fe();
     typename MatrixFree<dim, Number>::AdditionalData mf_data;
     mf_data.cell_vectorization_category          = cell_vectorization_category;
-    mf_data.cell_vectorization_categories_strict = true;
+    mf_data.cell_vectorization_categories_strict = false;
     mf_data.overlap_communication_computation    = false;
     mf_data.initialize_mapping                   = false;
     matrix_free.reinit(MappingQ1<dim>(), dof_handler, constraints, quadrature, mf_data);

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator_rt.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator_rt.h
@@ -307,7 +307,7 @@ public:
     MatrixFree<dim, Number>                          matrix_free;
     typename MatrixFree<dim, Number>::AdditionalData mf_data;
     mf_data.cell_vectorization_category          = cell_vectorization_category;
-    mf_data.cell_vectorization_categories_strict = true;
+    mf_data.cell_vectorization_categories_strict = false;
     mf_data.overlap_communication_computation    = false;
     mf_data.initialize_mapping                   = false;
     matrix_free.reinit(MappingQ1<dim>(), dof_handler, constraints, quadrature, mf_data);

--- a/include/exadg/operators/operator_base.cpp
+++ b/include/exadg/operators/operator_base.cpp
@@ -370,13 +370,11 @@ OperatorBase<dim, Number, n_components>::assemble_matrix_if_matrix_based() const
     // initialize matrix
     if(not(system_matrix_based_been_initialized))
     {
-      dealii::DoFHandler<dim> const & dof_handler =
-        this->matrix_free->get_dof_handler(this->data.dof_index);
-
       if(this->data.sparse_matrix_type == SparseMatrixType::Trilinos)
       {
 #ifdef DEAL_II_WITH_TRILINOS
-        init_system_matrix(system_matrix_trilinos, dof_handler.get_mpi_communicator());
+        init_system_matrix(system_matrix_trilinos,
+                           this->matrix_free->get_dof_handler().get_mpi_communicator());
 #else
         AssertThrow(
           false,
@@ -387,7 +385,8 @@ OperatorBase<dim, Number, n_components>::assemble_matrix_if_matrix_based() const
       else if(this->data.sparse_matrix_type == SparseMatrixType::PETSc)
       {
 #ifdef DEAL_II_WITH_PETSC
-        init_system_matrix(system_matrix_petsc, dof_handler.get_mpi_communicator());
+        init_system_matrix(system_matrix_petsc,
+                           this->matrix_free->get_dof_handler().get_mpi_communicator());
 #else
         AssertThrow(
           false,

--- a/include/exadg/time_integration/time_int_base.cpp
+++ b/include/exadg/time_integration/time_int_base.cpp
@@ -267,16 +267,24 @@ TimeIntBase::output_remaining_time() const
   {
     if(time > start_time)
     {
-      double const remaining_time =
-        global_timer.wall_time() * (end_time - time) / (time - start_time);
+      double const time_spent     = global_timer.wall_time();
+      double const remaining_time = time_spent * (end_time - time) / (time - start_time);
+
+      int const hours_spent   = int(time_spent / 3600.0);
+      int const minutes_spent = int((time_spent - hours_spent * 3600.0) / 60.0);
+      int const seconds_spent = int((time_spent - hours_spent * 3600.0 - minutes_spent * 60.0));
 
       int const hours   = int(remaining_time / 3600.0);
       int const minutes = int((remaining_time - hours * 3600.0) / 60.0);
       int const seconds = int((remaining_time - hours * 3600.0 - minutes * 60.0));
 
-      pcout << std::endl
-            << "Estimated time until completion is " << hours << " h " << minutes << " min "
-            << seconds << " s." << std::endl;
+      pcout << std::endl << "Spent ";
+      if(hours_spent > 0)
+        pcout << hours_spent << " h ";
+      pcout << minutes_spent << " min " << seconds_spent << " s, estimated time until completion: ";
+      if(hours > 0)
+        pcout << hours << " h ";
+      pcout << minutes << " min " << seconds << " s." << std::endl;
     }
   }
 }


### PR DESCRIPTION
This PR adds a more sophisticated scheme to order the cells. Together with a proposed improvement for deal.II at https://github.com/dealii/dealii/pull/19487, this significantly improves the access patterns in the code. The idea is to create a lexicographic-inspired number on batches of up to 8^3 cells. This gives many opportunities to fill up all SIMD lanes with similarly behaved cells, thus reducing the numbers of cells where the flux buffer of faces is not possible.

FYI @gshubhamk @richardschu  