### PR TITLE
Use incompressible strain-rate formulation for dissipation

### DIFF
--- a/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics_homogeneous.cpp
+++ b/include/exadg/incompressible_navier_stokes/postprocessor/line_plot_calculation_statistics_homogeneous.cpp
@@ -1266,11 +1266,9 @@ LinePlotCalculatorStatisticsHomogeneous<dim, Number>::do_evaluate(
 
                 if(need_dissipation)
                 {
-                  VectorizedArrayType epsilon_q = 0.0;
-                  for(unsigned int i = 0; i < dim; ++i)
-                    for(unsigned int j = 0; j < dim; ++j)
-                      epsilon_q += velocity_gradient[i][j] * velocity_gradient[i][j];
-                  epsilon_q *= viscosity;
+                  auto const S = 0.5 * (velocity_gradient + transpose(velocity_gradient));
+                  auto epsilon_q = 2.0 * viscosity * scalar_product(S,S);
+
                   dissipation += epsilon_q * JxW;
                 }
 


### PR DESCRIPTION
This PR updates the dissipation evaluation from

$$
\varepsilon = \nu \nabla u : \nabla u
$$

to the incompressible strain-rate tensor formulation

$$
S = \frac{1}{2}(\nabla u + \nabla u^T),
\qquad
\varepsilon = 2 \nu S:S.
$$

With this change, the grid-resolution plot appears more reasonable than before, although some inconsistencies still remain, particularly in the Kolmogorov length scale plots.

I would therefore suggest keeping this PR open for further discussion and testing, and merging once the remaining postprocessing issues have been resolved.
<img width="1173" height="901" alt="Screenshot from 2026-05-22 17-36-51" src="https://github.com/user-attachments/assets/112b64d0-ee0b-4b5e-915b-4598c3e17db0" />
<img width="1173" height="901" alt="Screenshot from 2026-05-22 17-37-33" src="https://github.com/user-attachments/assets/b52bc259-bb46-482b-9c51-6fd4d5a30e29" />
