### PR TITLE
Remove debug output. Disable manufactured solution by default.

### DIFF
--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -1246,7 +1246,7 @@ private:
   double       end_time = temporal_convergence_study ? 0.1 : end_time_multiples * flow_through_time;
 
   // compute convergence study else execute benchmark
-  bool use_manufactured_solution = true;
+  bool use_manufactured_solution = false;
 
   // grid
   bool   consider_box_distort = false; // distort the box grid before mapping

--- a/applications/incompressible_navier_stokes/periodic_hill/tests/spatial_convergence_run.mpirun=6.output
+++ b/applications/incompressible_navier_stokes/periodic_hill/tests/spatial_convergence_run.mpirun=6.output
@@ -119,26 +119,6 @@ Setup incompressible Navier-Stokes operator ...
 ... done!
 
 Setup Multistep time integrator ...
-Pre-/post distance > 1/2 size 1.3441e-01  [p4] 2.0091e-01  3.1579e-01  [p2]
-Pre-/post distance > 10       2.6344e-01  [p4] 3.3924e-01  4.7895e-01  [p2]
-Pre-/post distance > 1/2 size 8.0526e-01  [p2] 8.7928e-01  9.4086e-01  [p4]
-Pre-/post distance > 10       8.4737e-01  [p2] 8.9694e-01  9.4624e-01  [p4]
-Face flux buffer efficiency   6.7708e-01  [p2] 7.0486e-01  7.1875e-01  [p0]
-Pre-/post distance > 1/2 size 9.6774e-02  [p4] 1.7664e-01  3.2105e-01  [p2]
-Pre-/post distance > 10       9.6774e-02  [p4] 1.7664e-01  3.2105e-01  [p2]
-Pre-/post distance > 1/2 size 8.0526e-01  [p2] 8.7233e-01  9.3011e-01  [p4]
-Pre-/post distance > 10       8.0526e-01  [p2] 8.7233e-01  9.3011e-01  [p4]
-Face flux buffer efficiency   6.4583e-01  [p2] 7.0139e-01  7.2917e-01  [p0]
-Pre-/post distance > 1/2 size 2.3438e-02  [p0] 5.7292e-02  1.2500e-01  [p2]
-Pre-/post distance > 10       1.2500e-01  [p0] 1.5625e-01  2.1875e-01  [p2]
-Pre-/post distance > 1/2 size 6.7188e-01  [p2] 7.5000e-01  7.8906e-01  [p0]
-Pre-/post distance > 10       6.9531e-01  [p2] 7.7344e-01  8.1250e-01  [p0]
-Face flux buffer efficiency   6.7708e-01  [p2] 7.0486e-01  7.1875e-01  [p0]
-Pre-/post distance > 1/2 size 7.8125e-03  [p0] 4.6875e-02  1.2500e-01  [p2]
-Pre-/post distance > 10       7.8125e-03  [p0] 4.6875e-02  1.2500e-01  [p2]
-Pre-/post distance > 1/2 size 6.7188e-01  [p2] 7.4479e-01  7.8125e-01  [p0]
-Pre-/post distance > 10       6.7188e-01  [p2] 7.4479e-01  7.8125e-01  [p0]
-Face flux buffer efficiency   6.4583e-01  [p2] 7.0139e-01  7.2917e-01  [p0]
 
 Calculation of time step size according to CFL condition:
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
@@ -2011,6 +2011,9 @@ private:
       AssertThrow(index != numbers::invalid_unsigned_int, ExcInternalError());
     for(const auto & index : touched_last_by)
       AssertThrow(index != numbers::invalid_unsigned_int, ExcInternalError());
+
+    // debug output to assess sanity of implementation
+    if(false)
     {
       unsigned int n_batches_half = 0, n_batches_10 = 0;
       for(unsigned int i = 0; i < touched_first_by.size(); ++i)
@@ -2050,6 +2053,8 @@ private:
     std::cout << std::endl;
 #endif
 
+    // debug output to assess sanity of implementation
+    if(false)
     {
       unsigned int n_batches_half = 0, n_batches_10 = 0;
       for(unsigned int i = 0; i < touched_first_by.size(); ++i)
@@ -3313,9 +3318,11 @@ private:
         else
           ++count_1;
 
-    Helper::print_time(static_cast<double>(count_1) / (count_0 + count_1),
-                       "Face flux buffer efficiency",
-                       MPI_COMM_WORLD);
+    // debug output to assess sanity of implementation
+    if(false)
+      Helper::print_time(static_cast<double>(count_1) / (count_0 + count_1),
+                         "Face flux buffer efficiency",
+                         MPI_COMM_WORLD);
 
 #if 0
     std::cout << "Identified storage of length " << size_of_storage << " with "

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator_rt.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator_rt.h
@@ -1791,6 +1791,9 @@ private:
       AssertThrow(index != numbers::invalid_unsigned_int, ExcInternalError());
     for(const auto & index : touched_last_by)
       AssertThrow(index != numbers::invalid_unsigned_int, ExcInternalError());
+
+    // debug output to assess sanity of implementation
+    if(false)
     {
       unsigned int n_batches_half = 0, n_batches_10 = 0;
       for(unsigned int i = 0; i < touched_first_by.size(); ++i)
@@ -1858,6 +1861,8 @@ private:
     std::cout << std::endl;
 #endif
 
+    // debug output to assess sanity of implementation
+    if(false)
     {
       unsigned int n_batches_half = 0, n_batches_10 = 0;
       for(unsigned int i = 0; i < touched_first_by.size(); ++i)
@@ -6686,9 +6691,11 @@ private:
         else
           ++count_1;
 
-    Helper::print_time(static_cast<double>(count_1) / (count_0 + count_1),
-                       "Face flux buffer efficiency",
-                       MPI_COMM_WORLD);
+    // debug output to assess sanity of implementation
+    if(false)
+      Helper::print_time(static_cast<double>(count_1) / (count_0 + count_1),
+                         "Face flux buffer efficiency",
+                         MPI_COMM_WORLD);
 
 #if 0
     std::cout << "Identified storage of length " << size_of_storage << " with "


### PR DESCRIPTION
@richardschu here is the suggested fix to remove the output.

While there, I also changed the default for the manufactured solution to `false` because I do not want to change all my input files. Do you agree? I think the test file sets the case, so we should be able to use it this way.