### PR TITLE
Allow to specify only min degree

### DIFF
--- a/applications/incompressible_navier_stokes/periodic_hill/input.json
+++ b/applications/incompressible_navier_stokes/periodic_hill/input.json
@@ -6,9 +6,7 @@
     },
     "SpatialResolution": {
         "DegreeMin": "5",
-        "DegreeMax": "5",
-        "RefineSpaceMin": "3",
-        "RefineSpaceMax": "3"
+        "RefineSpaceMin": "3"
     },
     "TemporalResolution": {
         "RefineTimeMin": "0",

--- a/include/exadg/incompressible_navier_stokes/solver.h
+++ b/include/exadg/incompressible_navier_stokes/solver.h
@@ -147,12 +147,15 @@ main(int argc, char ** argv)
   ExaDG::SpatialResolutionParametersMinMax spatial(input_file);
   ExaDG::TemporalResolutionParameters      temporal(input_file);
 
-  // k-refinement
-  for(unsigned int degree = spatial.degree_min; degree <= spatial.degree_max; ++degree)
+  // k-refinement, including the case where we did not set degree_max and thu
+  // run the one degree set by degree_min
+  for(unsigned int degree = spatial.degree_min;
+      degree <= std::max(spatial.degree_max, spatial.degree_min);
+      ++degree)
   {
     // h-refinement
     for(unsigned int refine_space = spatial.refine_space_min;
-        refine_space <= spatial.refine_space_max;
+        refine_space <= std::max(spatial.refine_space_max, spatial.refine_space_min);
         ++refine_space)
     {
       // dt-refinement

--- a/include/exadg/operators/resolution_parameters.h
+++ b/include/exadg/operators/resolution_parameters.h
@@ -57,7 +57,7 @@ struct SpatialResolutionParametersMinMax
                         degree_max,
                         "Maximal polynomial degree of shape functions.",
                         dealii::Patterns::Integer(1),
-                        true);
+                        false);
       prm.add_parameter("RefineSpaceMin",
                         refine_space_min,
                         "Minimal number of mesh refinements.",
@@ -67,7 +67,7 @@ struct SpatialResolutionParametersMinMax
                         refine_space_max,
                         "Maximal number of mesh refinements.",
                         dealii::Patterns::Integer(0, 20),
-                        true);
+                        false);
     }
     prm.leave_subsection();
   }

--- a/include/exadg/operators/resolution_parameters.h
+++ b/include/exadg/operators/resolution_parameters.h
@@ -73,8 +73,8 @@ struct SpatialResolutionParametersMinMax
   }
 
   unsigned int degree_min = 3;
-unsigned int degree_min = 0;
-unsigned int degree_max = 0;
+  unsigned int degree_min = 0;
+  unsigned int degree_max = 0;
 
   unsigned int refine_space_min = 0;
   unsigned int refine_space_max = 0;

--- a/include/exadg/operators/resolution_parameters.h
+++ b/include/exadg/operators/resolution_parameters.h
@@ -73,7 +73,8 @@ struct SpatialResolutionParametersMinMax
   }
 
   unsigned int degree_min = 3;
-  unsigned int degree_max = 3;
+unsigned int degree_min = 0;
+unsigned int degree_max = 0;
 
   unsigned int refine_space_min = 0;
   unsigned int refine_space_max = 0;

--- a/include/exadg/operators/resolution_parameters.h
+++ b/include/exadg/operators/resolution_parameters.h
@@ -72,7 +72,6 @@ struct SpatialResolutionParametersMinMax
     prm.leave_subsection();
   }
 
-  unsigned int degree_min = 3;
   unsigned int degree_min = 0;
   unsigned int degree_max = 0;
 


### PR DESCRIPTION
I find it disturbing that all our cases need to specify a minimum refinement and maximum refinement level, and a minimum and a maximum degree. I always end up changing in two positions. While one could also aim for a more general solution, I believe it is already a big relieve if we can just specify one number and, in case only one of the parameters is given, we fill that second parameter automatically. It does lead to a slight change of behavior in some cases (when we would previously not run at all), but I think it is always preferable to make the common case more convenient than to catch something uncommon.