### PR TITLE
Enable solution projection between 'same' grids

### DIFF
--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -414,8 +414,8 @@ public:
 
     prm.enter_subsection("Application");
     {
-      prm.add_parameter("UseManufacturedSolution",
-                        use_manufactured_solution,
+      prm.add_parameter("ConvergenceStudy",
+                        convergence_study,
                         "Use a manufactured solution to compute errors in the box domain.",
                         dealii::Patterns::Bool());
       prm.add_parameter("ConsiderBoxDistort",
@@ -860,9 +860,9 @@ private:
   void
   set_field_functions() final
   {
-    if(use_manufactured_solution)
+    if(convergence_study)
     {
-      AssertThrow(use_manufactured_solution == true and consider_mapping == false,
+      AssertThrow(convergence_study == true and consider_mapping == false,
                   dealii::ExcMessage("Manufactured solution is defined on the box grid, "
                                      "cannot consider mapping to periodic hill."));
 
@@ -916,15 +916,13 @@ private:
     pp_data.output_data.write_vorticity           = true;
     pp_data.output_data.write_vorticity_magnitude = false;
     pp_data.output_data.write_q_criterion         = true;
-    pp_data.output_data.degree             = spatial_discretization == SpatialDiscretization::L2 ?
-                                               this->param.degree_u :
-                                               this->param.degree_u - 1;
-    pp_data.output_data.write_higher_order = true;
-    pp_data.output_data.write_aspect_ratio = false;
-    pp_data.output_data.write_processor_id = true;
+    pp_data.output_data.degree                    = this->param.degree_u;
+    pp_data.output_data.write_higher_order        = true;
+    pp_data.output_data.write_aspect_ratio        = false;
+    pp_data.output_data.write_processor_id        = true;
 
     // calculation of velocity error
-    pp_data.error_data_u.time_control_data.is_active  = true;
+    pp_data.error_data_u.time_control_data.is_active  = convergence_study;
     pp_data.error_data_u.time_control_data.start_time = start_time;
     pp_data.error_data_u.time_control_data.trigger_interval =
       convergence_study ? (end_time - start_time) / 10.0 : flow_through_time / 5.0;
@@ -932,8 +930,8 @@ private:
     pp_data.error_data_u.analytical_solution.reset(new ManufacturedSolutionVelocity<dim>(
       height_channel_at_hill_top, length_channel, y_shift, time_period));
     pp_data.error_data_u.name                      = "velocity";
-    pp_data.error_data_u.compute_convergence_table = use_manufactured_solution;
-    pp_data.error_data_u.write_errors_to_file      = use_manufactured_solution;
+    pp_data.error_data_u.compute_convergence_table = convergence_study;
+    pp_data.error_data_u.write_errors_to_file      = convergence_study;
     pp_data.error_data_u.calculate_relative_errors = false;
     pp_data.error_data_u.directory                 = this->output_parameters.directory;
 
@@ -944,8 +942,8 @@ private:
     pp_data.error_data_p.analytical_solution.reset(
       new ManufacturedSolutionPressure<dim>(length_channel, time_period));
     pp_data.error_data_p.name                      = "pressure";
-    pp_data.error_data_p.compute_convergence_table = use_manufactured_solution;
-    pp_data.error_data_p.write_errors_to_file      = use_manufactured_solution;
+    pp_data.error_data_p.compute_convergence_table = convergence_study;
+    pp_data.error_data_p.write_errors_to_file      = convergence_study;
     pp_data.error_data_p.calculate_relative_errors = false;
     pp_data.error_data_p.directory                 = this->output_parameters.directory;
 
@@ -1222,11 +1220,12 @@ private:
   // respect to the y coordinate. This compensates for the offset of the constructed domain.
   static double constexpr y_shift = height_hill + 0.5 * height_channel_at_hill_top;
 
+  // Activates manufactured solution case on undeformed box grid to compute errors.
+  bool convergence_study = false; // read from input file
+
   // For temporal convergence studies, we increase the frequency to increase the temporal error.
-  static bool constexpr convergence_study         = true;
   static bool constexpr spatial_convergence_study = true;
-  static bool constexpr temporal_convergence_study =
-    convergence_study and not spatial_convergence_study;
+  bool temporal_convergence_study = convergence_study and not spatial_convergence_study;
   static double constexpr time_period =
     2.0 * dealii::numbers::PI * (spatial_convergence_study ? 1.0 : 1e-4);
 
@@ -1244,9 +1243,6 @@ private:
   double const start_time         = 0.0;
   double       end_time_multiples = 10.0;
   double       end_time = temporal_convergence_study ? 0.1 : end_time_multiples * flow_through_time;
-
-  // compute convergence study else execute benchmark
-  bool use_manufactured_solution = false;
 
   // grid
   bool   consider_box_distort = false; // distort the box grid before mapping

--- a/applications/incompressible_navier_stokes/periodic_hill/tests/spatial_convergence_run.json
+++ b/applications/incompressible_navier_stokes/periodic_hill/tests/spatial_convergence_run.json
@@ -15,7 +15,7 @@
         "RefineTimeMax": "0"
     },
     "Application": {
-        "UseManufacturedSolution": "true",
+        "ConvergenceStudy": "true",
         "ConsiderBoxDistort": "true",
         "ConsiderMapping": "false",
         "TriangulationType": "Distributed",

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1342,6 +1342,7 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
 
   // Define grid-to-grid projection data for all projections used here.
   ExaDG::GridToGridProjection::GridToGridProjectionData<dim> projection_data;
+  projection_data.grids_and_maps_identical        = false;
   projection_data.solver_data                     = param.restart_data.solver_data;
   projection_data.rpe_data.rtree_level            = param.restart_data.rpe_rtree_level;
   projection_data.rpe_data.tolerance              = param.restart_data.rpe_tolerance_unit_cell;
@@ -1423,6 +1424,8 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
     // but between grids that have the same refinement level and mapping to improve stability by
     // *avoiding* `dealii::RemotePointEvaluation`.
     {
+      projection_data.grids_and_maps_identical = true;
+
       this->pcout << "\n"
                   << "VELOCITY PROJECTION IN DEFORMED GRID\n\n";
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -1427,7 +1427,7 @@ SpatialOperatorBase<dim, Number>::deserialize_vectors(std::vector<VectorType *> 
       projection_data.grids_and_maps_identical = true;
 
       this->pcout << "\n"
-                  << "VELOCITY PROJECTION IN DEFORMED GRID\n\n";
+                  << "VELOCITY PROJECTION IN DEFORMED GRID: FAST PATH AVOIDING RPE\n\n";
 
       checkpoint_mapping = this->get_mapping();
 

--- a/include/exadg/operators/solution_projection_between_triangulations.h
+++ b/include/exadg/operators/solution_projection_between_triangulations.h
@@ -56,7 +56,8 @@ struct GridToGridProjectionData
       solver_data(SolverData(1e3, 1e-20, 1e-6, LinearSolver::CG)),
       preconditioner(PreconditionerMass::PointJacobi),
       amg_data(AMGData()),
-      additional_quadrature_points(1)
+      additional_quadrature_points(1),
+      grids_and_maps_identical(false)
   {
   }
 
@@ -83,6 +84,11 @@ struct GridToGridProjectionData
   // The default `additional_quadrature_points = 1` considers `fe_degree + 1` quadrature points in
   // 1D using the `fe_degree` of the target grid's finite element.
   unsigned int additional_quadrature_points;
+
+  // Having identical grids and mappings, one can avoid RPE for mapped configurations. This flag has
+  // to be provided by the user, to avoid an expensive check for independent copies of identical
+  // grids and mappings.
+  bool grids_and_maps_identical;
 };
 
 /**
@@ -125,6 +131,79 @@ collect_integration_points(
   }
 
   return integration_points;
+}
+
+/**
+ * Utility function to compute the right-hand side of a projection (mass matrix solve), assuming the
+ * `dealii::DoFHandler`s corresponding to *identical* grids with *identical* mappings, which are
+ * distributed *identically*. The function space, however, might be different. We interpolate the
+ * source and assemble the projection right-hand side with the target finite element.
+ */
+template<int dim, int n_components, typename Number, typename VectorType>
+VectorType
+assemble_projection_rhs(VectorType &                              system_rhs,
+                        VectorType const &                        source_vector,
+                        dealii::DoFHandler<dim> const &           source_dof_handler,
+                        dealii::Mapping<dim> const &              source_and_target_mapping,
+                        dealii::DoFHandler<dim> const &           target_dof_handler,
+                        dealii::AffineConstraints<Number> const & target_constraints,
+                        dealii::Quadrature<dim> const &           quadrature_dim)
+{
+  // Check if the triangulations *might* be identical, assuming there is no adaptive refinement.
+  dealii::Triangulation<dim> const & source_triangulation = source_dof_handler.get_triangulation();
+  dealii::Triangulation<dim> const & target_triangulation = target_dof_handler.get_triangulation();
+  bool const                         spatial_resolution_identical =
+    source_triangulation.n_global_levels() == target_triangulation.n_global_levels() and
+    source_triangulation.n_global_active_cells() == target_triangulation.n_global_active_cells();
+  AssertThrow(spatial_resolution_identical == true,
+              dealii::ExcMessage("The triangulations used cannot be identical."));
+
+  dealii::FiniteElement<dim> const & source_fe = source_dof_handler.get_fe();
+  dealii::FiniteElement<dim> const & target_fe = target_dof_handler.get_fe();
+
+  const dealii::Quadrature<1> & quadrature = quadrature_dim.get_tensor_basis()[0];
+
+  dealii::FEEvaluation<dim, -1, 0, n_components, Number, dealii::VectorizedArray<Number, 1>>
+    fe_values_source(source_and_target_mapping, source_fe, quadrature, dealii::update_values);
+  dealii::FEEvaluation<dim, -1, 0, n_components, Number, dealii::VectorizedArray<Number, 1>>
+    fe_values_target(source_and_target_mapping,
+                     target_fe,
+                     quadrature,
+                     dealii::update_values | dealii::update_JxW_values);
+
+  dealii::Vector<Number>                       cell_rhs(target_fe.dofs_per_cell);
+  std::vector<dealii::types::global_dof_index> dof_indices(target_fe.dofs_per_cell);
+
+  for(const auto & cell_target : target_dof_handler.active_cell_iterators())
+  {
+    const auto cell_source = cell_target->as_dof_handler_iterator(source_dof_handler);
+    AssertThrow(cell_source->id() == cell_target->id(),
+                dealii::ExcMessage("Meshes were supposed to be iterated through the "
+                                   "same way, but got " +
+                                   cell_source->id().to_string() + " vs " +
+                                   cell_target->id().to_string()));
+
+    if(cell_target->is_locally_owned())
+    {
+      fe_values_source.reinit(cell_source);
+      fe_values_target.reinit(cell_target);
+
+      fe_values_source.read_dof_values(source_vector);
+      fe_values_source.evaluate(dealii::EvaluationFlags::values);
+      for(const unsigned int q : fe_values_source.quadrature_point_indices())
+        fe_values_target.submit_value(fe_values_source.get_value(q), q);
+
+      fe_values_target.integrate(dealii::EvaluationFlags::values);
+      for(unsigned int i = 0; i < cell_rhs.size(); ++i)
+        cell_rhs(fe_values_target.get_internal_dof_numbering()[i]) =
+          fe_values_target.begin_dof_values()[i][0];
+      cell_target->get_dof_indices(dof_indices);
+      target_constraints.distribute_local_to_global(cell_rhs, dof_indices, system_rhs);
+    }
+  }
+  system_rhs.compress(dealii::VectorOperation::add);
+
+  return system_rhs;
 }
 
 /**
@@ -225,71 +304,131 @@ project_vectors(
   InverseMassOperator<dim, n_components, Number> inverse_mass_operator;
   inverse_mass_operator.initialize(target_matrix_free, inverse_mass_operator_data);
 
-  dealii::Utilities::MPI::RemotePointEvaluation<dim> rpe_source(data.rpe_data);
+  MPI_Comm const             mpi_comm = source_dof_handler.get_mpi_communicator();
+  dealii::ConditionalOStream pcout(std::cout,
+                                   (dealii::Utilities::MPI::this_mpi_process(mpi_comm) == 0));
+  pcout << std::scientific << std::setprecision(4);
+  std::chrono::time_point<std::chrono::high_resolution_clock> time_start, time_end;
 
-  // The sequence of integration points follows from the sequence of points as encountered during
-  // cell batch loop.
-  std::vector<dealii::Point<dim>> integration_points_target =
-    collect_integration_points<dim, n_components, Number>(target_matrix_free,
-                                                          dof_index,
-                                                          quad_index);
-
-  rpe_source.reinit(integration_points_target,
-                    source_dof_handler.get_triangulation(),
-                    *source_mapping);
-
-  if(not rpe_source.all_points_found())
+  // If the grids and maps are *not* identical, interpolate the source grid in the target grid's
+  // integration points using `dealii::RemotePointEvaluation`.
+  std::shared_ptr<dealii::Utilities::MPI::RemotePointEvaluation<dim>> rpe_source =
+    std::make_shared<dealii::Utilities::MPI::RemotePointEvaluation<dim>>(data.rpe_data);
+  if(not data.grids_and_maps_identical)
   {
-    MPI_Comm const     mpi_comm         = source_dof_handler.get_mpi_communicator();
-    unsigned int const this_mpi_process = dealii::Utilities::MPI::this_mpi_process(mpi_comm);
-    write_points_in_dummy_triangulation(
-      integration_points_target, "./", "points_all", this_mpi_process, mpi_comm);
+    // The sequence of integration points follows from the sequence of points as encountered during
+    // cell batch loop.
+    std::vector<dealii::Point<dim>> integration_points_target =
+      collect_integration_points<dim, n_components, Number>(target_matrix_free,
+                                                            dof_index,
+                                                            quad_index);
 
-    std::vector<dealii::Point<dim>> points_not_found;
-    points_not_found.reserve(integration_points_target.size());
-    for(unsigned int i = 0; i < integration_points_target.size(); ++i)
+    time_start = std::chrono::high_resolution_clock::now();
+    rpe_source->reinit(integration_points_target,
+                       source_dof_handler.get_triangulation(),
+                       *source_mapping);
+    time_end = std::chrono::high_resolution_clock::now();
+
+    std::chrono::duration<double> time_elapsed_rpe_reinit = time_end - time_start;
+
+    pcout << "time: RPE reinit         " << time_elapsed_rpe_reinit.count() << " s\n";
+
+    if(not rpe_source->all_points_found())
     {
-      if(not rpe_source.point_found(i))
+      write_points_in_dummy_triangulation(integration_points_target,
+                                          "./",
+                                          "points_all",
+                                          dealii::Utilities::MPI::this_mpi_process(mpi_comm),
+                                          mpi_comm);
+
+      std::vector<dealii::Point<dim>> points_not_found;
+      points_not_found.reserve(integration_points_target.size());
+      for(unsigned int i = 0; i < integration_points_target.size(); ++i)
       {
-        points_not_found.push_back(integration_points_target[i]);
+        if(not rpe_source->point_found(i))
+        {
+          points_not_found.push_back(integration_points_target[i]);
+        }
       }
+
+      write_points_in_dummy_triangulation(points_not_found, "./", "points_not_found", 0, mpi_comm);
+
+      MPI_Barrier(mpi_comm);
+
+      AssertThrow(
+        rpe_source->all_points_found(),
+        dealii::ExcMessage(
+          "Could not interpolate source grid vector in target grid. "
+          "Points exported to `./points_all_points.pvtu` and `./points_not_found_points.pvtu`"));
     }
-
-    write_points_in_dummy_triangulation(
-      points_not_found, "./", "points_not_found", this_mpi_process, mpi_comm);
-
-    AssertThrow(
-      rpe_source.all_points_found(),
-      dealii::ExcMessage(
-        "Could not interpolate source grid vector in target grid. "
-        "Points exported to `./points_all_points.pvtu` and `./points_not_found_points.pvtu`"));
   }
 
   // Loop over vectors and project.
+  double time_elapsed_rpe_interpolate    = 0.0;
+  double time_elapsed_inverse_mass_rhs   = 0.0;
+  double time_elapsed_inverse_mass_apply = 0.0;
   for(unsigned int i = 0; i < target_vectors.size(); ++i)
   {
     // Evaluate the source vector at the target integration points.
     VectorType const & source_vector = *source_vectors.at(i);
     source_vector.update_ghost_values();
 
-    std::vector<
-      typename dealii::FEPointEvaluation<n_components, dim, dim, Number>::value_type> const
-      values_source_in_q_points_target = dealii::VectorTools::point_values<n_components>(
-        rpe_source, source_dof_handler, source_vector, dealii::VectorTools::EvaluationFlags::avg);
+    // Assemble right-hand side for the projection.
+    VectorType system_rhs;
+    if(data.grids_and_maps_identical)
+    {
+      time_start = std::chrono::high_resolution_clock::now();
+      target_matrix_free.initialize_dof_vector(system_rhs, dof_index);
+      assemble_projection_rhs<dim, n_components, Number, VectorType>(
+        system_rhs,
+        source_vector,
+        source_dof_handler,
+        *source_mapping /* source_and_target_mapping */,
+        target_matrix_free.get_dof_handler(dof_index),
+        target_matrix_free.get_affine_constraints(dof_index),
+        target_matrix_free.get_quadrature(quad_index));
+      time_end = std::chrono::high_resolution_clock::now();
+      time_elapsed_inverse_mass_rhs += std::chrono::duration<double>(time_end - time_start).count();
+    }
+    else
+    {
+      time_start = std::chrono::high_resolution_clock::now();
+      std::vector<
+        typename dealii::FEPointEvaluation<n_components, dim, dim, Number>::value_type> const
+        values_source_in_q_points_target = dealii::VectorTools::point_values<n_components>(
+          *rpe_source,
+          source_dof_handler,
+          source_vector,
+          dealii::VectorTools::EvaluationFlags::avg);
+      time_end = std::chrono::high_resolution_clock::now();
+      time_elapsed_rpe_interpolate += std::chrono::duration<double>(time_end - time_start).count();
 
-    // Assemble right-hand side vector for the projection.
-    VectorType system_rhs = assemble_projection_rhs<dim, n_components, Number, VectorType>(
-      target_matrix_free, values_source_in_q_points_target, dof_index, quad_index);
+      time_start = std::chrono::high_resolution_clock::now();
+      system_rhs = assemble_projection_rhs<dim, n_components, Number, VectorType>(
+        target_matrix_free, values_source_in_q_points_target, dof_index, quad_index);
+      time_end = std::chrono::high_resolution_clock::now();
+      time_elapsed_inverse_mass_rhs += std::chrono::duration<double>(time_end - time_start).count();
+    }
 
     // Solve linear system starting from zero initial guess.
     VectorType sol;
     sol.reinit(system_rhs, false /* omit_zeroing_entries */);
 
+    time_start = std::chrono::high_resolution_clock::now();
     inverse_mass_operator.apply(sol, system_rhs);
+    time_end = std::chrono::high_resolution_clock::now();
+    time_elapsed_inverse_mass_apply += std::chrono::duration<double>(time_end - time_start).count();
+
+    pcout << "global CG iterations in projection : "
+          << inverse_mass_operator.get_n_iter_global_last() << "\n";
 
     // Copy solution to target vector.
     *target_vectors[i] = sol;
   }
+
+  pcout << "time: RPE interpolate    " << time_elapsed_rpe_interpolate << " s\n";
+  pcout << "time: inverse mass rhs   " << time_elapsed_inverse_mass_rhs << " s\n";
+  pcout << "time: inverse mass apply " << time_elapsed_inverse_mass_apply << " s\n";
 }
 
 /**


### PR DESCRIPTION
@richardschu I know we did change some of this functionality in #29, but here is what I observed: When doing the restart for the periodic hill, the step from the intermediate DG space to the HDIV would use `RemotePointEvaluation` rather than the faster code. I am not entirely sure if I messed up something during getting the latest exadg/master in to the `martin` branch or if it is by construction, but overall what I see is a very slow restart. I tried this change. Do you see any problem with this? We might remove some of the output again if we agree, right now I restored the state in the relevant function before #29.

I still need to test all variants on cases as the previous one, but I would still appreciate some comments.