### PR TITLE
Implement multigrid semicoarsening option

### DIFF
--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -812,16 +812,27 @@ private:
       return points_moved;
     };
 
-    // Since we use a distorted mesh, apply an anisotropic coarsening (called
-    // semi-coarsening in the multigrid literature) to get good aspect-ratio
-    // cells eventually for multigrid. We store those cells in the respective
-    // data structure.
+    // Since we use a distorted mesh, using an anisotropic coarsening (called
+    // semi-coarsening in the multigrid literature) will allow us to get a
+    // better aspect-ratio cells eventually for multigrid. We hard-code a
+    // variant for a particular set of refinements in y-direction: In case the
+    // user gives us a mesh with 3 coarse grid cells and we additionally have
+    // at least 3 global refinements (giving a multiple of 24 cells in
+    // y-direction), we can use the following coarsening steps: 24 -> 18 -> 16
+    // cells. The number of coarse cells in x and z direction will not be
+    // changed.
     const unsigned int global_refinements = grid.triangulation->n_global_levels() - 1;
-    const unsigned int n_cells_vertical   = coarse_mesh_refinements[1] * (1 << global_refinements);
-    if(coarse_mesh_refinements[1] == 3 && n_cells_vertical % 24 == 0)
+    if(coarse_mesh_refinements[1] == 3 && global_refinements >= 3)
     {
       auto tria2 =
         std::make_shared<dealii::parallel::distributed::Triangulation<dim>>(MPI_COMM_WORLD);
+
+      // We will represent the next coarser mesh starting from a base mesh of
+      // 9 elements in vertical direction, which will be refined once more to
+      // get to 18 cells. Since the 9 mesh elements will be matched with a
+      // 12-cell base mesh, and we assumed the fine-level mesh to have started
+      // from 3 vertical cells, we need to multiply the x and z refinements by
+      // 4 to get the same number of cells.
       std::vector<unsigned int> refinements2{4 * coarse_mesh_refinements[0],
                                              9,
                                              4 * coarse_mesh_refinements[2]};
@@ -855,10 +866,21 @@ private:
 
       tria2->add_periodicity(periodic_face_pairs);
 
-      // move vertices, because we only want to refine the layer of cells
-      // closest to the boundary, but match the cells in the interior.
+      // Move vertices to match the anisotropically coarsened cells with the
+      // ones on the refined side to actually create a geometric nesting of
+      // cells. This is a crucial step, since the 'tria2' object we created
+      // here will have a different positioning of most vertices compared to
+      // the fine level one. Since the anisotropy will be injected by a
+      // mapping rather than represented in the triangulation, the vertex
+      // positions in y-direction will here be moved in steps of 2 of the fine
+      // mesh, using 3 layers both at the y-bottom and y-top region of 3
+      // coarse cells (6 fine cells). On the other hand, the position of the
+      // central part will be matched with the fine size.
       tria2->refine_global(1);
       const dealii::Triangulation<dim> & tria = *grid.triangulation;
+      AssertThrow(tria.n_levels() >= 4,
+                  dealii::ExcMessage("Expected to have at least 4 levels on the mesh when entering "
+                                     "this code path. Do you use more processes than mesh cells?"));
       const double        size_y = tria.begin(3)->vertex(2)[1] - tria.begin(3)->vertex(0)[1];
       std::vector<double> new_position(19);
       new_position[0] = p_1[1];
@@ -878,12 +900,21 @@ private:
         const_cast<dealii::Point<dim> &>(p)[1] = new_position[vertical_index];
       }
 
+      // Apply the remaining refinements and then append this triangulation to
+      // the coarse triangulations stored with the grid, which will be used
+      // for the multigrid setup.
       tria2->refine_global(global_refinements - 3);
       auto mapping2 = std::make_shared<dealii::MappingQCache<dim>>(this->param.mapping_degree);
       mapping2->initialize(*tria2, mapping_function_fine);
       grid.coarse_triangulations.push_back(tria2);
       grid.coarse_mappings.push_back(mapping2);
 
+      // Now to the next round of cells: This time, we target 2 coarse mesh
+      // cells with the same refinement applied as for the finest-level grid
+      // (i.e., 16 in refined configuration), which will be matched with the
+      // 18 cells on the next finer grid level. This means that we only
+      // coarsen the 2 cell layers closest to the boundary into 1 layer of
+      // cells.
       auto tria3 =
         std::make_shared<dealii::parallel::distributed::Triangulation<dim>>(MPI_COMM_WORLD);
       std::vector<unsigned int> refinements3{coarse_mesh_refinements[0],
@@ -916,16 +947,19 @@ private:
       }
       tria3->add_periodicity(periodic_face_pairs);
 
-      // move vertices to fit with coarser mesh
+      // Move vertices to fit with the next finer mesh: We want to aggregate 2
+      // layers of mesh elements closest to the boundary from the previous
+      // round into one cell layer. We pick up the values from the previous
+      // round to not make mistakes here.
       tria3->refine_global(3);
       std::vector<double> new_position3(17);
-      new_position3[0] = p_1[1];
-      new_position3[1] = p_1[1] + 4 * size_y;
-      new_position3[2] = p_1[1] + 6 * size_y;
+      new_position3[0] = new_position[0];
+      new_position3[1] = new_position[2];
+      new_position3[2] = new_position[3];
       for(unsigned int i = 3; i < 15; ++i)
-        new_position3[i] = p_1[1] + (i + 4) * size_y;
-      new_position3[15] = p_1[1] + 20 * size_y;
-      new_position3[16] = p_1[1] + 24 * size_y;
+        new_position3[i] = new_position[1 + i];
+      new_position3[15] = new_position[16];
+      new_position3[16] = new_position[18];
       AssertThrow(std::abs(new_position3[16] - p_2[1]) < 1e-12, dealii::ExcInternalError());
       for(const dealii::Point<dim> & p : tria3->get_vertices())
       {

--- a/applications/incompressible_navier_stokes/periodic_hill/application.h
+++ b/applications/incompressible_navier_stokes/periodic_hill/application.h
@@ -685,6 +685,17 @@ private:
               std::shared_ptr<dealii::Mapping<dim>> &           mapping,
               std::shared_ptr<MultigridMappings<dim, Number>> & multigrid_mappings) final
   {
+    dealii::Point<dim> p_1;
+    p_1[0] = 0.;
+    p_1[1] = height_hill;
+    if(dim == 3)
+      p_1[2] = -width_channel / 2.0;
+
+    dealii::Point<dim> p_2;
+    p_2[0] = length_channel;
+    p_2[1] = height_hill + height_channel_at_hill_top;
+    if(dim == 3)
+      p_2[2] = width_channel / 2.0;
     auto const lambda_create_triangulation = [&](dealii::Triangulation<dim, dim> & tria,
                                                  std::vector<dealii::GridTools::PeriodicFacePair<
                                                    typename dealii::Triangulation<
@@ -694,18 +705,6 @@ private:
                                                    vector_local_refinements) {
       (void)periodic_face_pairs;
       (void)vector_local_refinements;
-
-      dealii::Point<dim> p_1;
-      p_1[0] = 0.;
-      p_1[1] = height_hill;
-      if(dim == 3)
-        p_1[2] = -width_channel / 2.0;
-
-      dealii::Point<dim> p_2;
-      p_2[0] = length_channel;
-      p_2[1] = height_hill + height_channel_at_hill_top;
-      if(dim == 3)
-        p_2[2] = width_channel / 2.0;
 
       // use 2 cells in x-direction on coarsest grid and 1 cell in y- and z-directions
       std::vector<unsigned int> refinements{
@@ -775,10 +774,6 @@ private:
                                                               lambda_create_triangulation,
                                                               {} /* no local refinements */);
 
-    // mappings
-    AssertThrow(get_element_type(*grid.triangulation) == ElementType::Hypercube,
-                dealii::ExcMessage("Only implemented for hypercube elements."));
-
     // dummy FE for compatibility with interface of dealii::FEValues
     dealii::FE_Nothing<dim>         dummy_fe;
     dealii::MappingQ1<dim>          mapping_undeformed;
@@ -788,38 +783,171 @@ private:
                                     dealii::update_quadrature_points);
     const std::vector<unsigned int> hierarchic_to_lexicographic_numbering =
       dealii::FETools::hierarchic_to_lexicographic_numbering<dim>(this->param.mapping_degree);
+    const auto mapping_function_fine =
+      [&](typename dealii::Triangulation<dim>::cell_iterator const & cell)
+      -> std::vector<dealii::Point<dim>> {
+      PeriodicHillManifold<dim> manifold(height_hill,
+                                         length_channel,
+                                         height_channel_at_hill_top,
+                                         grid_stretch_factor);
+      fe_values.reinit(cell);
+
+      std::vector<dealii::Point<dim>> points_moved(fe_values.n_quadrature_points);
+      for(unsigned int i = 0; i < fe_values.n_quadrature_points; ++i)
+      {
+        // need to adjust for hierarchic numbering of
+        // dealii::MappingQCache
+        dealii::Point<dim> const point_in_box =
+          box_distort(fe_values.quadrature_point(hierarchic_to_lexicographic_numbering[i]),
+                      consider_box_distort,
+                      length_channel,
+                      height_hill,
+                      height_channel_at_hill_top);
+        if(consider_mapping)
+          points_moved[i] = manifold.push_forward(point_in_box);
+        else
+          points_moved[i] = point_in_box;
+      }
+
+      return points_moved;
+    };
+
+    // Since we use a distorted mesh, apply an anisotropic coarsening (called
+    // semi-coarsening in the multigrid literature) to get good aspect-ratio
+    // cells eventually for multigrid. We store those cells in the respective
+    // data structure.
+    const unsigned int global_refinements = grid.triangulation->n_global_levels() - 1;
+    const unsigned int n_cells_vertical   = coarse_mesh_refinements[1] * (1 << global_refinements);
+    if(coarse_mesh_refinements[1] == 3 && n_cells_vertical % 24 == 0)
+    {
+      auto tria2 =
+        std::make_shared<dealii::parallel::distributed::Triangulation<dim>>(MPI_COMM_WORLD);
+      std::vector<unsigned int> refinements2{4 * coarse_mesh_refinements[0],
+                                             9,
+                                             4 * coarse_mesh_refinements[2]};
+      dealii::GridGenerator::subdivided_hyper_rectangle(*tria2, refinements2, p_1, p_2);
+      for(const auto & cell : tria2->cell_iterators())
+      {
+        if(cell->at_boundary(0))
+          cell->face(0)->set_all_boundary_ids(0 + 10);
+        if(cell->at_boundary(1))
+          cell->face(1)->set_all_boundary_ids(1 + 10);
+
+        // periodicity in z-direction
+        if(dim == 3)
+        {
+          // left element
+          if(cell->at_boundary(4))
+            cell->face(4)->set_all_boundary_ids(2 + 10);
+          if(cell->at_boundary(5))
+            cell->face(5)->set_all_boundary_ids(3 + 10);
+        }
+      }
+
+      std::vector<
+        dealii::GridTools::PeriodicFacePair<typename dealii::Triangulation<dim>::cell_iterator>>
+        periodic_face_pairs;
+      dealii::GridTools::collect_periodic_faces(*tria2, 0 + 10, 1 + 10, 0, periodic_face_pairs);
+      if(dim == 3)
+      {
+        dealii::GridTools::collect_periodic_faces(*tria2, 2 + 10, 3 + 10, 2, periodic_face_pairs);
+      }
+
+      tria2->add_periodicity(periodic_face_pairs);
+
+      // move vertices, because we only want to refine the layer of cells
+      // closest to the boundary, but match the cells in the interior.
+      tria2->refine_global(1);
+      const dealii::Triangulation<dim> & tria = *grid.triangulation;
+      const double        size_y = tria.begin(3)->vertex(2)[1] - tria.begin(3)->vertex(0)[1];
+      std::vector<double> new_position(19);
+      new_position[0] = p_1[1];
+      new_position[1] = p_1[1] + 2 * size_y;
+      new_position[2] = p_1[1] + 4 * size_y;
+      new_position[3] = p_1[1] + 6 * size_y;
+      for(unsigned int i = 4; i < 16; ++i)
+        new_position[i] = p_1[1] + (i + 3) * size_y;
+      new_position[16] = p_1[1] + 20 * size_y;
+      new_position[17] = p_1[1] + 22 * size_y;
+      new_position[18] = p_1[1] + 24 * size_y;
+      AssertThrow(std::abs(new_position[18] - p_2[1]) < 1e-12, dealii::ExcInternalError());
+      for(const dealii::Point<dim> & p : tria2->get_vertices())
+      {
+        const unsigned int vertical_index =
+          static_cast<unsigned int>(18.000001 * (p[1] - p_1[1]) / (p_2[1] - p_1[1]));
+        const_cast<dealii::Point<dim> &>(p)[1] = new_position[vertical_index];
+      }
+
+      tria2->refine_global(global_refinements - 3);
+      auto mapping2 = std::make_shared<dealii::MappingQCache<dim>>(this->param.mapping_degree);
+      mapping2->initialize(*tria2, mapping_function_fine);
+      grid.coarse_triangulations.push_back(tria2);
+      grid.coarse_mappings.push_back(mapping2);
+
+      auto tria3 =
+        std::make_shared<dealii::parallel::distributed::Triangulation<dim>>(MPI_COMM_WORLD);
+      std::vector<unsigned int> refinements3{coarse_mesh_refinements[0],
+                                             2,
+                                             coarse_mesh_refinements[2]};
+      dealii::GridGenerator::subdivided_hyper_rectangle(*tria3, refinements3, p_1, p_2);
+      for(const auto & cell : tria3->cell_iterators())
+      {
+        if(cell->at_boundary(0))
+          cell->face(0)->set_all_boundary_ids(0 + 10);
+        if(cell->at_boundary(1))
+          cell->face(1)->set_all_boundary_ids(1 + 10);
+
+        // periodicity in z-direction
+        if(dim == 3)
+        {
+          // left element
+          if(cell->at_boundary(4))
+            cell->face(4)->set_all_boundary_ids(2 + 10);
+          if(cell->at_boundary(5))
+            cell->face(5)->set_all_boundary_ids(3 + 10);
+        }
+      }
+
+      periodic_face_pairs.clear();
+      dealii::GridTools::collect_periodic_faces(*tria3, 0 + 10, 1 + 10, 0, periodic_face_pairs);
+      if(dim == 3)
+      {
+        dealii::GridTools::collect_periodic_faces(*tria3, 2 + 10, 3 + 10, 2, periodic_face_pairs);
+      }
+      tria3->add_periodicity(periodic_face_pairs);
+
+      // move vertices to fit with coarser mesh
+      tria3->refine_global(3);
+      std::vector<double> new_position3(17);
+      new_position3[0] = p_1[1];
+      new_position3[1] = p_1[1] + 4 * size_y;
+      new_position3[2] = p_1[1] + 6 * size_y;
+      for(unsigned int i = 3; i < 15; ++i)
+        new_position3[i] = p_1[1] + (i + 4) * size_y;
+      new_position3[15] = p_1[1] + 20 * size_y;
+      new_position3[16] = p_1[1] + 24 * size_y;
+      AssertThrow(std::abs(new_position3[16] - p_2[1]) < 1e-12, dealii::ExcInternalError());
+      for(const dealii::Point<dim> & p : tria3->get_vertices())
+      {
+        const unsigned int vertical_index =
+          static_cast<unsigned int>(16.000001 * (p[1] - p_1[1]) / (p_2[1] - p_1[1]));
+        const_cast<dealii::Point<dim> &>(p)[1] = new_position3[vertical_index];
+      }
+
+      tria3->refine_global(global_refinements - 3);
+      auto mapping3 = std::make_shared<dealii::MappingQCache<dim>>(this->param.mapping_degree);
+      mapping3->initialize(*tria3, mapping_function_fine);
+      grid.coarse_triangulations.push_back(tria3);
+      grid.coarse_mappings.push_back(mapping3);
+    }
+
+    // mappings
+    AssertThrow(get_element_type(*grid.triangulation) == ElementType::Hypercube,
+                dealii::ExcMessage("Only implemented for hypercube elements."));
 
     const auto mapping_q_cache =
       std::make_shared<dealii::MappingQCache<dim>>(this->param.mapping_degree);
-    mapping_q_cache->initialize(
-      *grid.triangulation,
-      [&](typename dealii::Triangulation<dim>::cell_iterator const & cell)
-        -> std::vector<dealii::Point<dim>> {
-        PeriodicHillManifold<dim> manifold(height_hill,
-                                           length_channel,
-                                           height_channel_at_hill_top,
-                                           grid_stretch_factor);
-        fe_values.reinit(cell);
-
-        std::vector<dealii::Point<dim>> points_moved(fe_values.n_quadrature_points);
-        for(unsigned int i = 0; i < fe_values.n_quadrature_points; ++i)
-        {
-          // need to adjust for hierarchic numbering of
-          // dealii::MappingQCache
-          dealii::Point<dim> const point_in_box =
-            box_distort(fe_values.quadrature_point(hierarchic_to_lexicographic_numbering[i]),
-                        consider_box_distort,
-                        length_channel,
-                        height_hill,
-                        height_channel_at_hill_top);
-          if(consider_mapping)
-            points_moved[i] = manifold.push_forward(point_in_box);
-          else
-            points_moved[i] = point_in_box;
-        }
-
-        return points_moved;
-      });
+    mapping_q_cache->initialize(*grid.triangulation, mapping_function_fine);
 
     grid.mapping_function = [&](typename dealii::Triangulation<dim>::cell_iterator const & cell)
       -> std::vector<dealii::Point<dim>> {
@@ -920,7 +1048,6 @@ private:
     pp_data.output_data.time_control_data.start_time = start_time;
     pp_data.output_data.time_control_data.trigger_interval =
       convergence_study ? (end_time - start_time) / 10.0 : flow_through_time / 5.0;
-    ;
     pp_data.output_data.directory                 = this->output_parameters.directory + "vtu/";
     pp_data.output_data.filename                  = this->output_parameters.filename;
     pp_data.output_data.write_velocity_magnitude  = false;
@@ -938,7 +1065,6 @@ private:
     pp_data.error_data_u.time_control_data.start_time = start_time;
     pp_data.error_data_u.time_control_data.trigger_interval =
       convergence_study ? (end_time - start_time) / 10.0 : flow_through_time / 5.0;
-    ;
     pp_data.error_data_u.analytical_solution.reset(new ManufacturedSolutionVelocity<dim>(
       height_channel_at_hill_top, length_channel, y_shift, time_period));
     pp_data.error_data_u.name                      = "velocity";
@@ -950,7 +1076,6 @@ private:
     pp_data.error_data_p.time_control_data = pp_data.error_data_u.time_control_data;
     pp_data.error_data_p.time_control_data.trigger_interval =
       convergence_study ? (end_time - start_time) / 10.0 : flow_through_time / 5.0;
-    ;
     pp_data.error_data_p.analytical_solution.reset(
       new ManufacturedSolutionPressure<dim>(length_channel, time_period));
     pp_data.error_data_p.name                      = "pressure";

--- a/include/exadg/grid/grid.h
+++ b/include/exadg/grid/grid.h
@@ -63,6 +63,11 @@ public:
   std::vector<std::shared_ptr<dealii::Triangulation<dim> const>> coarse_triangulations;
 
   /**
+   * Same for coarser mappings.
+   */
+  std::vector<std::shared_ptr<dealii::Mapping<dim> const>> coarse_mappings;
+
+  /**
    * A vector of dealii::GridTools::PeriodicFacePair's for the coarse triangulations required for
    * h-multigrid with geometric coarsening types that require a vector of triangulations.
    *

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
@@ -202,6 +202,22 @@ compute_cell_lapl(const internal::MatrixFreeFunctions::UnivariateShapeData<Numbe
 
 
 
+// retrieve the coarsening sequence for p multigrid, defined in a central
+// place: pick the next coarser degree as half the previous degree; if integer
+// division has remainder, use the nearest even degree (i.e., we do steps like
+// 2-1, 3-2-1, 4-2-1, 5-2-1, 6-3-2-1, 7-4-2-1, etc)
+constexpr unsigned int
+get_coarser_fe_degree(const unsigned int degree)
+{
+  const unsigned int half = degree / 2;
+  if(degree % 2 == 1 && half % 2 == 1)
+    return half + 1;
+  else
+    return half;
+}
+
+
+
 template<int dim, typename Number = double>
 class LaplaceOperatorFE : public EnableObserverPointer
 {
@@ -449,7 +465,7 @@ public:
                              VectorizedArray<Number> * dof_values,
                              VectorType &              dst) const
   {
-    if(degree <= 2)
+    if constexpr(degree <= 2)
     {
       constexpr unsigned int dofs_per_cell = Utilities::pow(degree + 1, dim);
       const unsigned int *   dof_indices =
@@ -477,7 +493,7 @@ public:
                   const VectorType &        src,
                   VectorizedArray<Number> * dof_values) const
   {
-    if(degree <= 2)
+    if constexpr(degree <= 2)
     {
       constexpr unsigned int dofs_per_cell = Utilities::pow(degree + 1, dim);
       const unsigned int *   dof_indices =
@@ -500,6 +516,11 @@ public:
         src, compressed_dof_indices, all_indices_unconstrained, cell, {}, true, dof_values);
   }
 
+  const std::vector<unsigned int> &
+  get_compressed_dof_indices() const
+  {
+    return compressed_dof_indices;
+  }
 
 private:
   void
@@ -712,15 +733,16 @@ private:
     }
   }
 
+public:
   template<int fe_degree, int n_q_points_1d, int n_components>
-  void
+  static void
   read_dof_values_compressed(const VectorType &                    vec_in,
                              const std::vector<unsigned int> &     compressed_indices,
                              const std::vector<unsigned char> &    all_indices_unconstrained,
                              const unsigned int                    cell_no,
                              const dealii::AlignedVector<Number> & shape_values_eo,
                              const bool                            is_collocation,
-                             VectorizedArray<Number> *             dof_values) const
+                             VectorizedArray<Number> *             dof_values)
   {
     VectorType & vec = const_cast<VectorType &>(vec_in);
     AssertIndexRange(cell_no * dealii::Utilities::pow(3, dim) * VectorizedArray<Number>::size(),
@@ -935,7 +957,7 @@ private:
   }
 
   template<int fe_degree, int n_q_points_1d, int n_components>
-  void
+  static void
   distribute_local_to_global_compressed(
     VectorType &                          vec,
     const std::vector<unsigned int> &     compressed_indices,
@@ -943,7 +965,7 @@ private:
     const unsigned int                    cell_no,
     const dealii::AlignedVector<Number> & shape_values_eo,
     const bool                            is_collocation,
-    VectorizedArray<Number> *             dof_values) const
+    VectorizedArray<Number> *             dof_values)
   {
     AssertIndexRange(cell_no * dealii::Utilities::pow(3, dim) * VectorizedArray<Number>::size(),
                      compressed_indices.size());
@@ -1155,6 +1177,174 @@ private:
     }
   }
 
+  template<int fe_degree_templ = -1>
+  void
+  read_dof_values_compressed(const VectorType & vec,
+                             const unsigned int cell_no,
+                             const unsigned int simd_lane,
+                             Number *           dof_values) const
+  {
+    const unsigned int fe_degree =
+      fe_degree_templ > 0 ? fe_degree_templ : matrix_free.get_dof_handler().get_fe().degree;
+    AssertDimension(fe_degree, matrix_free.get_dof_handler().get_fe().degree);
+
+    if(fe_degree == 1)
+    {
+      AssertIndexRange(cell_no * n_lanes * dealii::Utilities::pow(2, dim) + simd_lane,
+                       compressed_dof_indices.size());
+      const unsigned int * cell_indices = compressed_dof_indices.data() +
+                                          cell_no * n_lanes * dealii::Utilities::pow(2, dim) +
+                                          simd_lane;
+      for(unsigned int i = 0; i < dealii::Utilities::pow(2, dim); ++i)
+        if(cell_indices[i * n_lanes] != numbers::invalid_unsigned_int)
+          dof_values[i] = vec.local_element(cell_indices[i * n_lanes]);
+        else
+          dof_values[i] = 0;
+      return;
+    }
+
+    AssertIndexRange(cell_no * n_lanes * dealii::Utilities::pow(3, dim) + simd_lane,
+                     compressed_dof_indices.size());
+    const unsigned int * cell_indices = compressed_dof_indices.data() +
+                                        cell_no * n_lanes * dealii::Utilities::pow(3, dim) +
+                                        simd_lane;
+
+    for(unsigned int i2 = 0, compressed_i2 = 0, offset_i2 = 0;
+        i2 < (dim == 3 ? (fe_degree + 1) : 1);
+        ++i2)
+    {
+      for(unsigned int i1 = 0, i = 0, compressed_i1 = 0, offset_i1 = 0;
+          i1 < (dim > 1 ? (fe_degree + 1) : 1);
+          ++i1)
+      {
+        const unsigned int offset =
+          (compressed_i1 == 1 ? fe_degree - 1 : 1) * offset_i2 + offset_i1;
+        const unsigned int * indices =
+          cell_indices + 3 * n_lanes * (compressed_i2 * 3 + compressed_i1);
+
+        // left end point
+        dof_values[i] = (indices[0] == dealii::numbers::invalid_unsigned_int) ?
+                          0. :
+                          vec.local_element(indices[0] + offset);
+        ++i;
+        indices += n_lanes;
+
+        // interior points of line
+        if(indices[0] != dealii::numbers::invalid_unsigned_int)
+          for(unsigned int i0 = 0; i0 < fe_degree - 1; ++i0, ++i)
+            dof_values[i] = vec.local_element(indices[0] + offset * (fe_degree - 1) + i0);
+        else
+          for(unsigned int i0 = 0; i0 < fe_degree - 1; ++i0, ++i)
+            dof_values[i] = 0.;
+        indices += n_lanes;
+
+        // right end point
+        dof_values[i] = (indices[0] == dealii::numbers::invalid_unsigned_int) ?
+                          0. :
+                          vec.local_element(indices[0] + offset);
+        ++i;
+
+        if(i1 == 0 || i1 == fe_degree - 1)
+        {
+          ++compressed_i1;
+          offset_i1 = 0;
+        }
+        else
+          ++offset_i1;
+      }
+
+      if(i2 == 0 || i2 == fe_degree - 1)
+      {
+        ++compressed_i2;
+        offset_i2 = 0;
+      }
+      else
+        ++offset_i2;
+
+      dof_values += (fe_degree + 1) * (fe_degree + 1);
+    }
+  }
+
+  template<int fe_degree_templ = -1>
+  void
+  distribute_local_to_global_compressed(VectorType &       vec,
+                                        const unsigned int cell_no,
+                                        const unsigned int simd_lane,
+                                        const Number *     dof_values) const
+  {
+    const unsigned int fe_degree =
+      fe_degree_templ > 0 ? fe_degree_templ : matrix_free.get_dof_handler().get_fe().degree;
+    AssertDimension(fe_degree, matrix_free.get_dof_handler().get_fe().degree);
+
+    if(fe_degree == 1)
+    {
+      AssertIndexRange(cell_no * n_lanes * dealii::Utilities::pow(2, dim) + simd_lane,
+                       compressed_dof_indices.size());
+      const unsigned int * cell_indices = compressed_dof_indices.data() +
+                                          cell_no * n_lanes * dealii::Utilities::pow(2, dim) +
+                                          simd_lane;
+      for(unsigned int i = 0; i < dealii::Utilities::pow(2, dim); ++i)
+        if(cell_indices[i * n_lanes] != numbers::invalid_unsigned_int)
+          vec.local_element(cell_indices[i * n_lanes]) += dof_values[i];
+      return;
+    }
+
+    AssertIndexRange(cell_no * n_lanes * dealii::Utilities::pow(3, dim) + simd_lane,
+                     compressed_dof_indices.size());
+    const unsigned int * cell_indices = compressed_dof_indices.data() +
+                                        cell_no * n_lanes * dealii::Utilities::pow(3, dim) +
+                                        simd_lane;
+
+    for(unsigned int i2 = 0, compressed_i2 = 0, offset_i2 = 0;
+        i2 < (dim == 3 ? (fe_degree + 1) : 1);
+        ++i2)
+    {
+      for(unsigned int i1 = 0, i = 0, compressed_i1 = 0, offset_i1 = 0;
+          i1 < (dim > 1 ? (fe_degree + 1) : 1);
+          ++i1)
+      {
+        const unsigned int offset =
+          (compressed_i1 == 1 ? fe_degree - 1 : 1) * offset_i2 + offset_i1;
+        const unsigned int * indices =
+          cell_indices + 3 * n_lanes * (compressed_i2 * 3 + compressed_i1);
+
+        // left end point
+        if(indices[0] != dealii::numbers::invalid_unsigned_int)
+          vec.local_element(indices[0] + offset) += dof_values[i];
+        ++i;
+        indices += n_lanes;
+
+        // interior points of line
+        if(indices[0] != dealii::numbers::invalid_unsigned_int)
+          for(unsigned int i0 = 0; i0 < fe_degree - 1; ++i0, ++i)
+            vec.local_element(indices[0] + (offset * (fe_degree - 1) + i0)) += dof_values[i];
+        indices += n_lanes;
+
+        // right end point
+        if(indices[0] != dealii::numbers::invalid_unsigned_int)
+          vec.local_element(indices[0] + offset) += dof_values[i];
+        ++i;
+
+        if(i1 == 0 || i1 == fe_degree - 1)
+        {
+          ++compressed_i1;
+          offset_i1 = 0;
+        }
+        else
+          ++offset_i1;
+      }
+      if(i2 == 0 || i2 == fe_degree - 1)
+      {
+        ++compressed_i2;
+        offset_i2 = 0;
+      }
+      else
+        ++offset_i2;
+      dof_values += (fe_degree + 1) * (fe_degree + 1);
+    }
+  }
+
+private:
   ObserverPointer<const DoFHandler<dim>> dof_handler;
   MatrixFree<dim, Number>                matrix_free;
   std::vector<unsigned int>              compressed_dof_indices;

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h
@@ -737,7 +737,7 @@ public:
   template<int fe_degree, int n_q_points_1d, int n_components>
   static void
   read_dof_values_compressed(const VectorType &                    vec_in,
-                             const std::vector<unsigned int> &     compressed_indices,
+                             const std::vector<unsigned int> &     compressed_dof_indices,
                              const std::vector<unsigned char> &    all_indices_unconstrained,
                              const unsigned int                    cell_no,
                              const dealii::AlignedVector<Number> & shape_values_eo,
@@ -745,10 +745,10 @@ public:
                              VectorizedArray<Number> *             dof_values)
   {
     VectorType & vec = const_cast<VectorType &>(vec_in);
-    AssertIndexRange(cell_no * dealii::Utilities::pow(3, dim) * VectorizedArray<Number>::size(),
-                     compressed_indices.size());
+    AssertIndexRange(cell_no * dealii::Utilities::pow(3, dim) * n_lanes,
+                     compressed_dof_indices.size());
     const unsigned int * cell_indices =
-      compressed_indices.data() + cell_no * n_lanes * dealii::Utilities::pow(3, dim);
+      compressed_dof_indices.data() + cell_no * n_lanes * dealii::Utilities::pow(3, dim);
     const unsigned char * cell_unconstrained =
       all_indices_unconstrained.data() + cell_no * dealii::Utilities::pow(3, dim);
     constexpr unsigned int dofs_per_comp = dealii::Utilities::pow(n_q_points_1d, dim);
@@ -960,17 +960,17 @@ public:
   static void
   distribute_local_to_global_compressed(
     VectorType &                          vec,
-    const std::vector<unsigned int> &     compressed_indices,
+    const std::vector<unsigned int> &     compressed_dof_indices,
     const std::vector<unsigned char> &    all_indices_unconstrained,
     const unsigned int                    cell_no,
     const dealii::AlignedVector<Number> & shape_values_eo,
     const bool                            is_collocation,
     VectorizedArray<Number> *             dof_values)
   {
-    AssertIndexRange(cell_no * dealii::Utilities::pow(3, dim) * VectorizedArray<Number>::size(),
-                     compressed_indices.size());
+    AssertIndexRange(cell_no * dealii::Utilities::pow(3, dim) * n_lanes,
+                     compressed_dof_indices.size());
     const unsigned int * cell_indices =
-      compressed_indices.data() + cell_no * n_lanes * dealii::Utilities::pow(3, dim);
+      compressed_dof_indices.data() + cell_no * n_lanes * dealii::Utilities::pow(3, dim);
     const unsigned char * cell_unconstrained =
       all_indices_unconstrained.data() + cell_no * dealii::Utilities::pow(3, dim);
     constexpr unsigned int dofs_per_comp = dealii::Utilities::pow(n_q_points_1d, dim);

--- a/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
@@ -42,6 +42,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include <exadg/incompressible_navier_stokes/spatial_discretization/operators/laplace_operator_extruded.h>
+#include <exadg/operators/constraints.h>
 
 
 namespace LaplaceOperator
@@ -68,53 +69,11 @@ make_zero_mean(const std::vector<unsigned int> &                    constrained_
 
 
 
-// Manually implement periodicity constraints, because the deal.II
-// implementation places the constraints the 'wrong' way around, leading to a
-// case with more unknowns on the processor with the lower rank and less on
-// the higher ranks. This function constrains the unknown on the lower-left
-// boundary by the one on the upper-right boundary. This is coherent with the
-// strategy that DoFs on interfaces of two processes are assigned to the
-// process with lower rank.
-namespace Periodicity
-{
-template<typename FaceIterator, typename Number>
-void
-make_periodicity_constraints_recursively(const FaceIterator &                             face_1,
-                                         const std_cxx20::type_identity_t<FaceIterator> & face_2,
-                                         AffineConstraints<Number> & affine_constraints)
-{
-  if(face_1->has_children())
-  {
-    if(!face_2->has_children())
-      return;
-    for(unsigned int i = 0; i < face_1->n_children(); ++i)
-      make_periodicity_constraints_recursively(face_1->child(i),
-                                               face_2->child(i),
-                                               affine_constraints);
-  }
-  else
-  {
-    const unsigned int                   dofs_per_face = face_1->get_fe(0).n_dofs_per_face(0);
-    std::vector<types::global_dof_index> dofs_1(dofs_per_face);
-    std::vector<types::global_dof_index> dofs_2(dofs_per_face);
-
-    face_1->get_dof_indices(dofs_1, 0);
-    face_2->get_dof_indices(dofs_2, 0);
-    for(unsigned int i = 0; i < dofs_per_face; ++i)
-      if(dofs_1[i] == numbers::invalid_dof_index || dofs_2[i] == numbers::invalid_dof_index)
-        return;
-    for(unsigned int i = 0; i < dofs_per_face; ++i)
-    {
-      if(!affine_constraints.is_constrained(dofs_1[i]))
-        affine_constraints.add_constraint(dofs_1[i], {{dofs_2[i], 1.0}});
-    }
-  }
-}
-
-} // namespace Periodicity
-
-
-
+/**
+ * This is a specialized transfer operator, designed for transfer between
+ * p-levels only, that aims to utilize the fact that we have the same cells
+ * and the same cell order to design a highly efficient transfer operation.
+ */
 template<int dim, typename Number>
 class MGTwoLevelTransferFromOperator
   : public MGTwoLevelTransferBase<dim, LinearAlgebra::distributed::Vector<Number>>
@@ -127,6 +86,63 @@ public:
                                  const LaplaceOperatorFE<dim, Number> & operator_coarse)
     : operator_fine(operator_fine), operator_coarse(operator_coarse)
   {
+    AssertThrow(operator_fine.get_matrix_free()
+                    .get_dof_handler()
+                    .get_triangulation()
+                    .n_global_active_cells() == operator_coarse.get_matrix_free()
+                                                  .get_dof_handler()
+                                                  .get_triangulation()
+                                                  .n_global_active_cells(),
+                ExcMessage("This transfer is designed for polynomial transfer between "
+                           "matrix-free operators defined on the same mesh, but found "
+                           "meshes with " +
+                           std::to_string(operator_fine.get_matrix_free()
+                                            .get_dof_handler()
+                                            .get_triangulation()
+                                            .n_global_active_cells()) +
+                           " and " +
+                           std::to_string(operator_coarse.get_matrix_free()
+                                            .get_dof_handler()
+                                            .get_triangulation()
+                                            .n_global_active_cells()) +
+                           " global cells, respectively."));
+    AssertThrow(
+      operator_fine.get_matrix_free().get_dof_handler().get_triangulation().n_active_cells() ==
+        operator_coarse.get_matrix_free().get_dof_handler().get_triangulation().n_active_cells(),
+      ExcMessage(
+        "This transfer is designed for polynomial transfer between "
+        "matrix-free operators defined on the same mesh partitioned "
+        "in the same way, but found meshes with " +
+        std::to_string(
+          operator_fine.get_matrix_free().get_dof_handler().get_triangulation().n_active_cells()) +
+        " and " +
+        std::to_string(operator_coarse.get_matrix_free()
+                         .get_dof_handler()
+                         .get_triangulation()
+                         .n_active_cells()) +
+        " cells owned on the current MPI process, respectively."));
+    AssertDimension(operator_fine.get_matrix_free().n_cell_batches(),
+                    operator_coarse.get_matrix_free().n_cell_batches());
+    for(unsigned int cell = 0; cell < operator_fine.get_matrix_free().n_cell_batches(); ++cell)
+    {
+      for(unsigned int v = 0;
+          v < operator_fine.get_matrix_free().n_active_entries_per_cell_batch(cell);
+          ++v)
+      {
+        AssertThrow(
+          operator_fine.get_matrix_free().get_cell_iterator(cell, v)->level() ==
+              operator_coarse.get_matrix_free().get_cell_iterator(cell, v)->level() &&
+            operator_fine.get_matrix_free().get_cell_iterator(cell, v)->index() ==
+              operator_coarse.get_matrix_free().get_cell_iterator(cell, v)->index(),
+          ExcMessage(
+            "The cell iterators on refined / coarse side did not match, "
+            "do both MatrixFree objects use the same ordering of cells? Got: " +
+            operator_fine.get_matrix_free().get_cell_iterator(cell, v)->id().to_string() + " vs " +
+            operator_coarse.get_matrix_free().get_cell_iterator(cell, v)->id().to_string() + " " +
+            std::to_string(cell) + " " + std::to_string(v)));
+      }
+    }
+
     // find unique indices of prolongation to identify the actual read pattern
     fine_dof_indices = operator_fine.get_compressed_dof_indices();
     const unsigned int degree_fine =
@@ -143,25 +159,6 @@ public:
         touched_dof[dof] = 1;
       else
         dof = numbers::invalid_unsigned_int;
-
-    for(unsigned int cell = 0; cell < operator_fine.get_matrix_free().n_cell_batches(); ++cell)
-    {
-      for(unsigned int v = 0;
-          v < operator_fine.get_matrix_free().n_active_entries_per_cell_batch(cell);
-          ++v)
-      {
-        AssertThrow(
-          operator_fine.get_matrix_free().get_cell_iterator(cell, v)->level() ==
-              operator_coarse.get_matrix_free().get_cell_iterator(cell, v)->level() &&
-            operator_fine.get_matrix_free().get_cell_iterator(cell, v)->index() ==
-              operator_coarse.get_matrix_free().get_cell_iterator(cell, v)->index(),
-          ExcMessage(
-            "Mismatch in cells " +
-            operator_fine.get_matrix_free().get_cell_iterator(cell, v)->id().to_string() + " vs " +
-            operator_coarse.get_matrix_free().get_cell_iterator(cell, v)->id().to_string() + " " +
-            std::to_string(cell) + " " + std::to_string(v)));
-      }
-    }
 
     all_indices_unconstrained.resize(fine_dof_indices.size() / n_lanes, 0);
 
@@ -187,9 +184,8 @@ public:
   {
     src.update_ghost_values();
 
-    const unsigned int size_fine = prolongation_matrix.n();
-    const unsigned int n_cell_batches =
-      fine_dof_indices.size() / n_lanes / Utilities::pow(std::min(3u, size_fine), dim);
+    const unsigned int size_fine      = prolongation_matrix.n();
+    const unsigned int n_cell_batches = operator_fine.get_matrix_free().n_cell_batches();
     for(unsigned int cell = 0; cell < n_cell_batches; ++cell)
     {
       if(size_fine == 2)
@@ -223,10 +219,8 @@ public:
   void
   restrict_and_add(VectorType & dst, const VectorType & src) const override
   {
-    const unsigned int size_fine = prolongation_matrix.n();
-    const unsigned int n_cell_batches =
-      fine_dof_indices.size() / n_lanes /
-      Utilities::pow(std::min<unsigned int>(3u, prolongation_matrix.n()), dim);
+    const unsigned int size_fine      = prolongation_matrix.n();
+    const unsigned int n_cell_batches = operator_fine.get_matrix_free().n_cell_batches();
     for(unsigned int cell = 0; cell < n_cell_batches; ++cell)
     {
       if(size_fine == 2)
@@ -342,6 +336,13 @@ private:
 
 
 
+/**
+ * This is a specialized transfer operator for doing anisotropic transfer,
+ * implemented for nested meshes with all information embedded into the meshes
+ * of operator_fine and operator_coarse. Compared to the deal.II class
+ * MGTwoLevelTransferNonnested, this class aims to be more efficient by
+ * computing a nested transfer.
+ */
 template<int dim, typename Number>
 class MGTwoLevelTransferAnisotropicNested
   : public MGTwoLevelTransferBase<dim, LinearAlgebra::distributed::Vector<Number>>
@@ -1182,7 +1183,7 @@ dealii::RepartitioningPolicyTools::MinimalGranularityPolicy<dim>(64)*/)),
         GridTools::collect_periodic_faces(
           dof_h, periodic_ids[d][0], periodic_ids[d][1], d, periodic_faces);
     for(const auto & face_pair : periodic_faces)
-      Periodicity::make_periodicity_constraints_recursively(
+      ExaDG::Periodicity::make_periodicity_constraints_recursively(
         face_pair.cell[0]->face(face_pair.face_idx[0]),
         face_pair.cell[1]->face(face_pair.face_idx[1]),
         level_constraints);
@@ -1197,7 +1198,7 @@ dealii::RepartitioningPolicyTools::MinimalGranularityPolicy<dim>(64)*/)),
     level_constraints.reinit(dof_h.locally_owned_dofs(),
                              dealii::DoFTools::extract_locally_relevant_dofs(dof_h));
     for(const auto & face_pair : periodic_faces)
-      Periodicity::make_periodicity_constraints_recursively(
+      ExaDG::Periodicity::make_periodicity_constraints_recursively(
         face_pair.cell[0]->face(face_pair.face_idx[0]),
         face_pair.cell[1]->face(face_pair.face_idx[1]),
         level_constraints);

--- a/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
@@ -1113,41 +1113,47 @@ dealii::RepartitioningPolicyTools::MinimalGranularityPolicy<dim>(64)*/)),
       {
         auto transfer = std::make_unique<MGTwoLevelTransferAnisotropicNested<dim, Number>>(
           mg_matrices[level], mg_matrices[level - 1]);
-        /*
-        MGTwoLevelTransferNonNested<dim, VectorType> transfer_nonnested;
-        MappingQ1<dim>                               mapping;
-        transfer_nonnested.reinit(dof_handler_hierarchy[level],
-                                  dof_handler_hierarchy[level - 1],
-                                  mapping,
-                                  mapping,
-                                  level_constraints[level],
-                                  level_constraints[level - 1]);
-        VectorType v1, v2, v3, v4;
-        mg_matrices[level - 1].initialize_dof_vector(v1);
-        mg_matrices[level - 1].initialize_dof_vector(v4);
-        mg_matrices[level].initialize_dof_vector(v2);
-        mg_matrices[level].initialize_dof_vector(v3);
-        Tensor<1, dim> tens;
-        tens[0] = 1;
-        tens[1] = 1;
-        tens[2] = 1;
-        VectorTools::interpolate(mapping,
-                                 dof_handler_hierarchy[level - 1],
-                                 Functions::Monomial<dim, Number>(tens, 1),
-                                 v1);
-        transfer->prolongate_and_add(v2, v1);
-        transfer_nonnested.prolongate_and_add(v3, v1);
-        std::cout << "Prolongate norms: " << v2.l2_norm() << " " << v3.l2_norm() << " difference ";
-        v2 -= v3;
-        std::cout << v2.l2_norm() << std::endl;
-        v1 = 0;
-        v4 = 0;
-        transfer->restrict_and_add(v1, v3);
-        transfer_nonnested.restrict_and_add(v4, v3);
-        std::cout << "Restrict norms: " << v1.l2_norm() << " " << v4.l2_norm() << " difference ";
-        v1 -= v4;
-        std::cout << v1.l2_norm() << std::endl;
-        */
+        // Compare the nested anisotropic transfer result with the output of
+        // the (more general) non-nested transfer of deal.II to ensure
+        // correctness of the result.
+        bool constexpr perform_check = false;
+        if constexpr(perform_check)
+        {
+          MGTwoLevelTransferNonNested<dim, VectorType> transfer_nonnested;
+          MappingQ1<dim>                               mapping;
+          transfer_nonnested.reinit(dof_handler_hierarchy[level],
+                                    dof_handler_hierarchy[level - 1],
+                                    mapping,
+                                    mapping,
+                                    level_constraints[level],
+                                    level_constraints[level - 1]);
+          VectorType v1, v2, v3, v4;
+          mg_matrices[level - 1].initialize_dof_vector(v1);
+          mg_matrices[level - 1].initialize_dof_vector(v4);
+          mg_matrices[level].initialize_dof_vector(v2);
+          mg_matrices[level].initialize_dof_vector(v3);
+          Tensor<1, dim> tens;
+          tens[0] = 1;
+          tens[1] = 1;
+          tens[2] = 1;
+          VectorTools::interpolate(mapping,
+                                   dof_handler_hierarchy[level - 1],
+                                   Functions::Monomial<dim, Number>(tens, 1),
+                                   v1);
+          transfer->prolongate_and_add(v2, v1);
+          transfer_nonnested.prolongate_and_add(v3, v1);
+          std::cout << "Prolongate norms: " << v2.l2_norm() << " " << v3.l2_norm()
+                    << " difference ";
+          v2 -= v3;
+          std::cout << v2.l2_norm() << std::endl;
+          v1 = 0;
+          v4 = 0;
+          transfer->restrict_and_add(v1, v3);
+          transfer_nonnested.restrict_and_add(v4, v3);
+          std::cout << "Restrict norms: " << v1.l2_norm() << " " << v4.l2_norm() << " difference ";
+          v1 -= v4;
+          std::cout << v1.l2_norm() << std::endl;
+        }
         mg_transfers[level - 1] = std::move(transfer);
       }
     }

--- a/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
@@ -68,6 +68,810 @@ make_zero_mean(const std::vector<unsigned int> &                    constrained_
 
 
 
+// Manually implement periodicity constraints, because the deal.II
+// implementation places the constraints the 'wrong' way around, leading to a
+// case with more unknowns on the processor with the lower rank and less on
+// the higher ranks. This function constrains the unknown on the lower-left
+// boundary by the one on the upper-right boundary. This is coherent with the
+// strategy that DoFs on interfaces of two processes are assigned to the
+// process with lower rank.
+namespace Periodicity
+{
+template<typename FaceIterator, typename Number>
+void
+make_periodicity_constraints_recursively(const FaceIterator &                             face_1,
+                                         const std_cxx20::type_identity_t<FaceIterator> & face_2,
+                                         AffineConstraints<Number> & affine_constraints)
+{
+  if(face_1->has_children())
+  {
+    if(!face_2->has_children())
+      return;
+    for(unsigned int i = 0; i < face_1->n_children(); ++i)
+      make_periodicity_constraints_recursively(face_1->child(i),
+                                               face_2->child(i),
+                                               affine_constraints);
+  }
+  else
+  {
+    const unsigned int                   dofs_per_face = face_1->get_fe(0).n_dofs_per_face(0);
+    std::vector<types::global_dof_index> dofs_1(dofs_per_face);
+    std::vector<types::global_dof_index> dofs_2(dofs_per_face);
+
+    face_1->get_dof_indices(dofs_1, 0);
+    face_2->get_dof_indices(dofs_2, 0);
+    for(unsigned int i = 0; i < dofs_per_face; ++i)
+      if(dofs_1[i] == numbers::invalid_dof_index || dofs_2[i] == numbers::invalid_dof_index)
+        return;
+    for(unsigned int i = 0; i < dofs_per_face; ++i)
+    {
+      if(!affine_constraints.is_constrained(dofs_1[i]))
+        affine_constraints.add_constraint(dofs_1[i], {{dofs_2[i], 1.0}});
+    }
+  }
+}
+
+} // namespace Periodicity
+
+
+
+template<int dim, typename Number>
+class MGTwoLevelTransferFromOperator
+  : public MGTwoLevelTransferBase<dim, LinearAlgebra::distributed::Vector<Number>>
+{
+public:
+  using VectorType                      = LinearAlgebra::distributed::Vector<Number>;
+  static constexpr unsigned int n_lanes = VectorizedArray<Number>::size();
+
+  MGTwoLevelTransferFromOperator(const LaplaceOperatorFE<dim, Number> & operator_fine,
+                                 const LaplaceOperatorFE<dim, Number> & operator_coarse)
+    : operator_fine(operator_fine), operator_coarse(operator_coarse)
+  {
+    // find unique indices of prolongation to identify the actual read pattern
+    fine_dof_indices = operator_fine.get_compressed_dof_indices();
+    const unsigned int degree_fine =
+      operator_fine.get_matrix_free().get_dof_handler().get_fe().degree;
+    const unsigned int degree_coarse =
+      operator_coarse.get_matrix_free().get_dof_handler().get_fe().degree;
+    const unsigned int n_owned_dofs =
+      operator_fine.get_matrix_free().get_dof_handler().locally_owned_dofs().n_elements();
+    std::vector<char> touched_dof(n_owned_dofs, 0);
+    for(unsigned int & dof : fine_dof_indices)
+      if(dof >= n_owned_dofs)
+        dof = numbers::invalid_unsigned_int;
+      else if(touched_dof[dof] == 0)
+        touched_dof[dof] = 1;
+      else
+        dof = numbers::invalid_unsigned_int;
+
+    for(unsigned int cell = 0; cell < operator_fine.get_matrix_free().n_cell_batches(); ++cell)
+    {
+      for(unsigned int v = 0;
+          v < operator_fine.get_matrix_free().n_active_entries_per_cell_batch(cell);
+          ++v)
+      {
+        AssertThrow(
+          operator_fine.get_matrix_free().get_cell_iterator(cell, v)->level() ==
+              operator_coarse.get_matrix_free().get_cell_iterator(cell, v)->level() &&
+            operator_fine.get_matrix_free().get_cell_iterator(cell, v)->index() ==
+              operator_coarse.get_matrix_free().get_cell_iterator(cell, v)->index(),
+          ExcMessage(
+            "Mismatch in cells " +
+            operator_fine.get_matrix_free().get_cell_iterator(cell, v)->id().to_string() + " vs " +
+            operator_coarse.get_matrix_free().get_cell_iterator(cell, v)->id().to_string() + " " +
+            std::to_string(cell) + " " + std::to_string(v)));
+      }
+    }
+
+    all_indices_unconstrained.resize(fine_dof_indices.size() / n_lanes, 0);
+
+    std::vector<Polynomials::Polynomial<double>> poly_coarse =
+      Polynomials::generate_complete_Lagrange_basis(
+        QGaussLobatto<1>(degree_coarse + 1).get_points());
+    std::vector<Point<1>> points_fine(QGaussLobatto<1>(degree_fine + 1).get_points());
+    prolongation_matrix.reinit(degree_coarse + 1, degree_fine + 1);
+    for(unsigned int i = 0; i < prolongation_matrix.m(); ++i)
+      for(unsigned int j = 0; j < prolongation_matrix.n(); ++j)
+        prolongation_matrix(i, j) = poly_coarse[i].value(points_fine[j][0]);
+    prolongation_matrix_data.resize(prolongation_matrix.m() * prolongation_matrix.n());
+    for(unsigned int i = 0, c = 0; i < prolongation_matrix.m(); ++i)
+      for(unsigned int j = 0; j < prolongation_matrix.n(); ++j, ++c)
+        prolongation_matrix_data[c] = prolongation_matrix(i, j);
+  }
+
+  /**
+   * @copydoc MGTwoLevelTransferBase::prolongate_and_add
+   */
+  void
+  prolongate_and_add(VectorType & dst, const VectorType & src) const override
+  {
+    src.update_ghost_values();
+
+    const unsigned int size_fine = prolongation_matrix.n();
+    const unsigned int n_cell_batches =
+      fine_dof_indices.size() / n_lanes / Utilities::pow(std::min(3u, size_fine), dim);
+    for(unsigned int cell = 0; cell < n_cell_batches; ++cell)
+    {
+      if(size_fine == 2)
+        do_prolongate_and_add_on_cell<2>(cell, dst, src);
+      else if(size_fine == 3)
+        do_prolongate_and_add_on_cell<3>(cell, dst, src);
+      else if(size_fine == 4)
+        do_prolongate_and_add_on_cell<4>(cell, dst, src);
+      else if(size_fine == 5)
+        do_prolongate_and_add_on_cell<5>(cell, dst, src);
+      else if(size_fine == 6)
+        do_prolongate_and_add_on_cell<6>(cell, dst, src);
+      else if(size_fine == 7)
+        do_prolongate_and_add_on_cell<7>(cell, dst, src);
+      else if(size_fine == 8)
+        do_prolongate_and_add_on_cell<8>(cell, dst, src);
+      else if(size_fine == 9)
+        do_prolongate_and_add_on_cell<9>(cell, dst, src);
+      else
+        AssertThrow(false,
+                    ExcMessage("Fine degree " + std::to_string(size_fine - 1) +
+                               " not instantiated"));
+    }
+
+    src.zero_out_ghost_values();
+  }
+
+  /**
+   * @copydoc MGTwoLevelTransferBase::restrict_and_add
+   */
+  void
+  restrict_and_add(VectorType & dst, const VectorType & src) const override
+  {
+    const unsigned int size_fine = prolongation_matrix.n();
+    const unsigned int n_cell_batches =
+      fine_dof_indices.size() / n_lanes /
+      Utilities::pow(std::min<unsigned int>(3u, prolongation_matrix.n()), dim);
+    for(unsigned int cell = 0; cell < n_cell_batches; ++cell)
+    {
+      if(size_fine == 2)
+        do_restrict_and_add_on_cell<2>(cell, dst, src);
+      else if(size_fine == 3)
+        do_restrict_and_add_on_cell<3>(cell, dst, src);
+      else if(size_fine == 4)
+        do_restrict_and_add_on_cell<4>(cell, dst, src);
+      else if(size_fine == 5)
+        do_restrict_and_add_on_cell<5>(cell, dst, src);
+      else if(size_fine == 6)
+        do_restrict_and_add_on_cell<6>(cell, dst, src);
+      else if(size_fine == 7)
+        do_restrict_and_add_on_cell<7>(cell, dst, src);
+      else if(size_fine == 8)
+        do_restrict_and_add_on_cell<8>(cell, dst, src);
+      else if(size_fine == 9)
+        do_restrict_and_add_on_cell<9>(cell, dst, src);
+      else
+        AssertThrow(false,
+                    ExcMessage("Fine degree " + std::to_string(size_fine - 1) +
+                               " not instantiated"));
+    }
+
+    dst.compress(VectorOperation::add);
+  }
+
+  void
+  interpolate(VectorType &, const VectorType &) const override
+  {
+    AssertThrow(false, ExcNotImplemented());
+  }
+
+  std::pair<bool, bool>
+  enable_inplace_operations_if_possible(
+    const std::shared_ptr<const Utilities::MPI::Partitioner> &,
+    const std::shared_ptr<const Utilities::MPI::Partitioner> &) override
+  {
+    return std::make_pair(true, true);
+  }
+
+  std::size_t
+  memory_consumption() const override
+  {
+    return MemoryConsumption::memory_consumption(fine_dof_indices) +
+           MemoryConsumption::memory_consumption(all_indices_unconstrained) +
+           prolongation_matrix.memory_consumption() + prolongation_matrix_data.memory_consumption();
+  }
+
+  std::pair<const DoFHandler<dim> *, unsigned int>
+  get_dof_handler_fine() const override
+  {
+    return std::make_pair(&operator_fine.get_matrix_free().get_dof_handler(),
+                          numbers::invalid_unsigned_int);
+  }
+
+private:
+  const LaplaceOperatorFE<dim, Number> & operator_fine;
+  const LaplaceOperatorFE<dim, Number> & operator_coarse;
+  std::vector<unsigned int>              fine_dof_indices;
+  std::vector<unsigned char>             all_indices_unconstrained;
+  FullMatrix<Number>                     prolongation_matrix;
+  AlignedVector<Number>                  prolongation_matrix_data;
+
+  template<int size_fine>
+  void
+  do_prolongate_and_add_on_cell(const unsigned int cell,
+                                VectorType &       dst,
+                                const VectorType & src) const
+  {
+    constexpr int size_coarse = get_coarser_fe_degree(size_fine - 1) + 1;
+    AssertDimension(prolongation_matrix.m(), size_coarse);
+    VectorizedArray<Number> tmp[Utilities::pow(size_fine, dim)];
+
+    operator_coarse.template read_dof_values<size_coarse - 1>(cell, src, tmp);
+    dealii::internal::FEEvaluationImplBasisChange<dealii::internal::evaluate_general,
+                                                  dealii::internal::EvaluatorQuantity::value,
+                                                  dim,
+                                                  size_coarse,
+                                                  size_fine>::do_forward(1,
+                                                                         prolongation_matrix_data,
+                                                                         tmp,
+                                                                         tmp);
+
+    operator_fine.template distribute_local_to_global_compressed<size_fine - 1, size_fine, 1>(
+      dst, fine_dof_indices, all_indices_unconstrained, cell, {}, true, tmp);
+  }
+
+  template<int size_fine>
+  void
+  do_restrict_and_add_on_cell(const unsigned int cell,
+                              VectorType &       dst,
+                              const VectorType & src) const
+  {
+    constexpr int size_coarse = get_coarser_fe_degree(size_fine - 1) + 1;
+    AssertDimension(prolongation_matrix.m(), size_coarse);
+    VectorizedArray<Number> tmp[Utilities::pow(size_fine, dim)];
+
+    operator_fine.template read_dof_values_compressed<size_fine - 1, size_fine, 1>(
+      src, fine_dof_indices, all_indices_unconstrained, cell, {}, true, tmp);
+    dealii::internal::FEEvaluationImplBasisChange<dealii::internal::evaluate_general,
+                                                  dealii::internal::EvaluatorQuantity::value,
+                                                  dim,
+                                                  size_coarse,
+                                                  size_fine>::do_backward(1,
+                                                                          prolongation_matrix_data,
+                                                                          false,
+                                                                          tmp,
+                                                                          tmp);
+    operator_coarse.template distribute_local_to_global<size_coarse - 1>(cell, tmp, dst);
+  }
+};
+
+
+
+template<int dim, typename Number>
+class MGTwoLevelTransferAnisotropicNested
+  : public MGTwoLevelTransferBase<dim, LinearAlgebra::distributed::Vector<Number>>
+{
+public:
+  using VectorType                      = LinearAlgebra::distributed::Vector<Number>;
+  static constexpr unsigned int n_lanes = VectorizedArray<Number>::size();
+
+  MGTwoLevelTransferAnisotropicNested(
+    const LaplaceOperator::LaplaceOperatorFE<dim, Number> & operator_fine,
+    const LaplaceOperator::LaplaceOperatorFE<dim, Number> & operator_coarse)
+    : operator_fine(operator_fine), operator_coarse(operator_coarse)
+  {
+    // find unique indices of prolongation to identify the actual read pattern
+    fine_dof_indices = operator_fine.get_compressed_dof_indices();
+    const unsigned int degree_fine =
+      operator_fine.get_matrix_free().get_dof_handler().get_fe().degree;
+    const unsigned int n_owned_dofs =
+      operator_fine.get_matrix_free().get_dof_handler().locally_owned_dofs().n_elements();
+    std::vector<char> touched_dof(n_owned_dofs, 0);
+    for(unsigned int & dof : fine_dof_indices)
+      if(dof >= n_owned_dofs)
+        dof = numbers::invalid_unsigned_int;
+      else if(touched_dof[dof] == 0)
+        touched_dof[dof] = 1;
+      else
+        dof = numbers::invalid_unsigned_int;
+
+    all_indices_unconstrained.resize(fine_dof_indices.size() / n_lanes, 0);
+
+    const DoFHandler<dim> & dof_handler_coarse =
+      operator_coarse.get_matrix_free().get_dof_handler();
+    const MPI_Comm communicator = dof_handler_coarse.get_mpi_communicator();
+
+    // Identify cells on coarser level for data import
+    const Triangulation<dim> & tria_coarse(dof_handler_coarse.get_triangulation());
+
+    // Step 1: For each cell, identify the cell on the coarse level where a
+    // cell from the fine level is contained in. We do this by a geometric
+    // search, whose result is the global index of cells queried from the
+    // process owing those cells, and the respective reference coordinates,
+    // which we use for the computation of the interpolation matrix.
+    const auto &            mf      = operator_coarse.get_matrix_free();
+    const auto &            mf_fine = operator_fine.get_matrix_free();
+    std::vector<Point<dim>> cell_centers;
+    cell_centers.reserve(mf_fine.n_cell_batches() * n_lanes);
+    for(unsigned int c = 0; c < mf_fine.n_cell_batches(); ++c)
+      for(unsigned int v = 0; v < mf_fine.n_active_entries_per_cell_batch(c); ++v)
+        cell_centers.push_back(mf_fine.get_cell_iterator(c, v)->center());
+
+    Utilities::MPI::RemotePointEvaluation<dim> point_eval_cache;
+    point_eval_cache.reinit(cell_centers, tria_coarse, MappingQ1<dim>());
+    using data_pair = std::pair<types::global_cell_index, Point<dim>>;
+    std::vector<data_pair> indices_of_needed_cells, buffer;
+    const auto             evaluation_function =
+      [&](const ArrayView<data_pair> &                                          values,
+          const typename Utilities::MPI::RemotePointEvaluation<dim>::CellData & cell_data) {
+        for(unsigned int i = 0; i < cell_data.cells.size(); ++i)
+        {
+          typename Triangulation<dim>::active_cell_iterator cell = {&tria_coarse,
+                                                                    cell_data.cells[i].first,
+                                                                    cell_data.cells[i].second};
+          for(unsigned int q = cell_data.reference_point_ptrs[i];
+              q < cell_data.reference_point_ptrs[i + 1];
+              ++q)
+          {
+            values[q] =
+              std::make_pair(cell->global_active_cell_index(), cell_data.reference_point_values[q]);
+          }
+        }
+      };
+
+    point_eval_cache.template evaluate_and_process<data_pair>(indices_of_needed_cells,
+                                                              buffer,
+                                                              evaluation_function);
+
+    // Collect all requested cells in the form of an IndexSet, which we use
+    // for communicating the solution values on the coarse side to the owner
+    // on the refined side, where the interpolation process is performed
+    IndexSet owned_cells =
+      tria_coarse.global_active_cell_index_partitioner().lock()->locally_owned_range();
+    IndexSet requested_cells(tria_coarse.n_global_active_cells());
+    for(const data_pair & item : indices_of_needed_cells)
+      requested_cells.add_index(item.first);
+
+    const unsigned int dofs_per_cell = mf.get_dof_handler().get_fe().dofs_per_cell;
+    partitioner_coarse_cells =
+      std::make_shared<Utilities::MPI::Partitioner>(owned_cells, requested_cells, communicator);
+    data_sent.resize(partitioner_coarse_cells->n_import_indices() * dofs_per_cell);
+    data_received.resize(partitioner_coarse_cells->n_ghost_indices() * dofs_per_cell);
+
+    std::vector<unsigned int> active_cell_index_to_index(
+      partitioner_coarse_cells->locally_owned_size());
+    for(unsigned int cell = 0; cell < mf.n_cell_batches(); ++cell)
+      for(unsigned int v = 0; v < mf.n_active_entries_per_cell_batch(cell); ++v)
+      {
+        const auto dcell                      = mf.get_cell_iterator(cell, v);
+        active_cell_index_to_index[partitioner_coarse_cells->global_to_local(
+          dcell->global_active_cell_index())] = cell * n_lanes + v;
+      }
+
+    unsigned int count = 0;
+    cell_indices_to_send.resize(partitioner_coarse_cells->n_import_indices());
+    for(const auto & import_range : partitioner_coarse_cells->import_indices())
+      for(unsigned int j = import_range.first; j < import_range.second; ++j, ++count)
+        cell_indices_to_send[count] = active_cell_index_to_index[j];
+    AssertDimension(count, cell_indices_to_send.size());
+
+    cell_indices_to_be_read.clear();
+    cell_indices_to_be_read.resize(mf_fine.n_cell_batches() * n_lanes,
+                                   numbers::invalid_unsigned_int);
+
+    count = 0;
+    interpolation_index_of_cells.resize(mf_fine.n_cell_batches());
+    const unsigned int size_prol = (dof_handler_coarse.get_fe().degree + 1) * (degree_fine + 1);
+    for(unsigned int c = 0; c < mf_fine.n_cell_batches(); ++c)
+      for(unsigned int v = 0; v < mf_fine.n_active_entries_per_cell_batch(c); ++v, ++count)
+      {
+        const auto & item        = indices_of_needed_cells[count];
+        unsigned int local_index = partitioner_coarse_cells->global_to_local(item.first);
+        if(local_index < partitioner_coarse_cells->locally_owned_size())
+          cell_indices_to_be_read[c * n_lanes + v] = active_cell_index_to_index[local_index];
+        else
+          cell_indices_to_be_read[c * n_lanes + v] = local_index;
+        const Point<dim> ref_point = item.second;
+        for(unsigned int d = 0; d < dim; ++d)
+        {
+          if(std::abs(ref_point[d] - 0.25) < 1e-10)
+            interpolation_index_of_cells[c][d][v] = 1 * size_prol;
+          else if(std::abs(ref_point[d] - 0.75) < 1e-10)
+            interpolation_index_of_cells[c][d][v] = 2 * size_prol;
+          else if(std::abs(ref_point[d] - 0.5) < 1e-10)
+            interpolation_index_of_cells[c][d][v] = 0;
+          else
+            AssertThrow(false,
+                        ExcMessage("Could not detect coarsening pattern, "
+                                   "got position " +
+                                   std::to_string(ref_point[d]) + ", expected 0.25, 0.5 or 0.75"));
+        }
+      }
+
+    std::vector<Polynomials::Polynomial<double>> poly =
+      Polynomials::generate_complete_Lagrange_basis(
+        QGaussLobatto<1>(dof_handler_coarse.get_fe().degree + 1).get_points());
+    std::vector<Point<1>> points_fine(QGaussLobatto<1>(degree_fine + 1).get_points());
+    prolongation_matrix_data.resize(3 * size_prol);
+    for(unsigned int i = 0; i < poly.size(); ++i)
+      for(unsigned int j = 0; j < degree_fine + 1; ++j)
+      {
+        prolongation_matrix_data[i * (degree_fine + 1) + j] = static_cast<Number>(i == j);
+        prolongation_matrix_data[size_prol + i * (degree_fine + 1) + j] =
+          poly[i].value(0.5 * points_fine[j][0]);
+        prolongation_matrix_data[2 * size_prol + i * (degree_fine + 1) + j] =
+          poly[i].value(0.5 + 0.5 * points_fine[j][0]);
+      }
+  }
+
+  /**
+   * @copydoc MGTwoLevelTransferBase::prolongate_and_add
+   */
+  void
+  prolongate_and_add(VectorType & dst, const VectorType & src) const override
+  {
+    // Retrieve solution from coarse space into a separate field that gets
+    // communicated (cells not present in the local range of the solution
+    // vector) or by reading directly on the locally owned cells
+    src.update_ghost_values();
+    const unsigned int dofs_per_cell =
+      operator_coarse.get_matrix_free().get_dof_handler().get_fe().dofs_per_cell;
+
+    std::vector<MPI_Request> requests(partitioner_coarse_cells->import_targets().size() +
+                                      partitioner_coarse_cells->ghost_targets().size());
+    unsigned int             offset = 0, count_request = 0;
+    for(const auto & target : partitioner_coarse_cells->ghost_targets())
+    {
+      const auto ierr = MPI_Irecv(data_received.data() + offset,
+                                  target.second * dofs_per_cell * sizeof(Number),
+                                  MPI_BYTE,
+                                  target.first,
+                                  15,
+                                  src.get_mpi_communicator(),
+                                  &requests[count_request]);
+      AssertThrowMPI(ierr);
+      offset += target.second * dofs_per_cell;
+      ++count_request;
+    }
+
+    unsigned int count_cell = 0;
+    offset                  = 0;
+    for(const auto & target : partitioner_coarse_cells->import_targets())
+    {
+      for(unsigned int i = 0; i < target.second; ++i, ++count_cell)
+        operator_coarse.read_dof_values_compressed(src,
+                                                   cell_indices_to_send[count_cell] / n_lanes,
+                                                   cell_indices_to_send[count_cell] % n_lanes,
+                                                   data_sent.data() + offset + i * dofs_per_cell);
+      const auto ierr = MPI_Isend(data_sent.data() + offset,
+                                  target.second * dofs_per_cell * sizeof(Number),
+                                  MPI_BYTE,
+                                  target.first,
+                                  15,
+                                  src.get_mpi_communicator(),
+                                  &requests[count_request]);
+      AssertThrowMPI(ierr);
+      offset += target.second * dofs_per_cell;
+      ++count_request;
+    }
+    AssertDimension(offset, data_sent.size());
+    AssertDimension(count_request, requests.size());
+
+    if(requests.size() > 0)
+    {
+      const int ierr = MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
+      AssertThrowMPI(ierr);
+    }
+
+    const unsigned int size_fine =
+      operator_fine.get_matrix_free().get_dof_handler().get_fe().degree + 1;
+    const unsigned int n_cell_batches =
+      fine_dof_indices.size() / n_lanes / Utilities::pow(std::min(3u, size_fine), dim);
+    for(unsigned int cell = 0; cell < n_cell_batches; ++cell)
+    {
+      if(size_fine == 2)
+        do_prolongate_and_add_on_cell<2>(cell, dst, src);
+      else if(size_fine == 3)
+        do_prolongate_and_add_on_cell<3>(cell, dst, src);
+      else if(size_fine == 4)
+        do_prolongate_and_add_on_cell<4>(cell, dst, src);
+      else if(size_fine == 5)
+        do_prolongate_and_add_on_cell<5>(cell, dst, src);
+      else if(size_fine == 6)
+        do_prolongate_and_add_on_cell<6>(cell, dst, src);
+      else if(size_fine == 7)
+        do_prolongate_and_add_on_cell<7>(cell, dst, src);
+      else if(size_fine == 8)
+        do_prolongate_and_add_on_cell<8>(cell, dst, src);
+      else if(size_fine == 9)
+        do_prolongate_and_add_on_cell<9>(cell, dst, src);
+      else
+        AssertThrow(false,
+                    ExcMessage("Fine degree " + std::to_string(size_fine - 1) +
+                               " not instantiated"));
+    }
+
+    src.zero_out_ghost_values();
+  }
+
+  /**
+   * @copydoc MGTwoLevelTransferBase::restrict_and_add
+   */
+  void
+  restrict_and_add(VectorType & dst, const VectorType & src) const override
+  {
+    const unsigned int size_fine =
+      operator_fine.get_matrix_free().get_dof_handler().get_fe().degree + 1;
+    const unsigned int n_cell_batches = fine_dof_indices.size() / n_lanes /
+                                        Utilities::pow(std::min<unsigned int>(3u, size_fine), dim);
+    std::fill(data_received.begin(), data_received.end(), Number(0));
+    for(unsigned int cell = 0; cell < n_cell_batches; ++cell)
+    {
+      if(size_fine == 2)
+        do_restrict_and_add_on_cell<2>(cell, dst, src);
+      else if(size_fine == 3)
+        do_restrict_and_add_on_cell<3>(cell, dst, src);
+      else if(size_fine == 4)
+        do_restrict_and_add_on_cell<4>(cell, dst, src);
+      else if(size_fine == 5)
+        do_restrict_and_add_on_cell<5>(cell, dst, src);
+      else if(size_fine == 6)
+        do_restrict_and_add_on_cell<6>(cell, dst, src);
+      else if(size_fine == 7)
+        do_restrict_and_add_on_cell<7>(cell, dst, src);
+      else if(size_fine == 8)
+        do_restrict_and_add_on_cell<8>(cell, dst, src);
+      else if(size_fine == 9)
+        do_restrict_and_add_on_cell<9>(cell, dst, src);
+      else
+        AssertThrow(false,
+                    ExcMessage("Fine degree " + std::to_string(size_fine - 1) +
+                               " not instantiated"));
+    }
+
+    const unsigned int dofs_per_cell =
+      operator_coarse.get_matrix_free().get_dof_handler().get_fe().dofs_per_cell;
+
+    std::vector<MPI_Request> requests(partitioner_coarse_cells->import_targets().size() +
+                                      partitioner_coarse_cells->ghost_targets().size());
+    unsigned int             offset = 0, count_request = 0;
+    for(const auto & target : partitioner_coarse_cells->import_targets())
+    {
+      const auto ierr = MPI_Irecv(data_sent.data() + offset,
+                                  target.second * dofs_per_cell * sizeof(Number),
+                                  MPI_BYTE,
+                                  target.first,
+                                  15,
+                                  dst.get_mpi_communicator(),
+                                  &requests[count_request]);
+      AssertThrowMPI(ierr);
+      offset += target.second * dofs_per_cell;
+      ++count_request;
+    }
+
+    offset = 0;
+    for(const auto & target : partitioner_coarse_cells->ghost_targets())
+    {
+      const auto ierr = MPI_Isend(data_received.data() + offset,
+                                  target.second * dofs_per_cell * sizeof(Number),
+                                  MPI_BYTE,
+                                  target.first,
+                                  15,
+                                  dst.get_mpi_communicator(),
+                                  &requests[count_request]);
+      AssertThrowMPI(ierr);
+      offset += target.second * dofs_per_cell;
+      ++count_request;
+    }
+    AssertDimension(count_request, requests.size());
+
+    if(requests.size() > 0)
+    {
+      const int ierr = MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
+      AssertThrowMPI(ierr);
+    }
+    for(unsigned int i = 0; i < partitioner_coarse_cells->n_import_indices(); ++i)
+      operator_coarse.distribute_local_to_global_compressed(dst,
+                                                            cell_indices_to_send[i] / n_lanes,
+                                                            cell_indices_to_send[i] % n_lanes,
+                                                            data_sent.data() + i * dofs_per_cell);
+
+    dst.compress(VectorOperation::add);
+  }
+
+  void
+  interpolate(VectorType &, const VectorType &) const override
+  {
+    AssertThrow(false, ExcNotImplemented());
+  }
+
+  std::pair<bool, bool>
+  enable_inplace_operations_if_possible(
+    const std::shared_ptr<const Utilities::MPI::Partitioner> &,
+    const std::shared_ptr<const Utilities::MPI::Partitioner> &) override
+  {
+    return std::make_pair(true, true);
+  }
+
+  std::size_t
+  memory_consumption() const override
+  {
+    return MemoryConsumption::memory_consumption(fine_dof_indices) +
+           MemoryConsumption::memory_consumption(all_indices_unconstrained) +
+           MemoryConsumption::memory_consumption(prolongation_matrix_data) +
+           MemoryConsumption::memory_consumption(cell_indices_to_be_read) +
+           MemoryConsumption::memory_consumption(cell_indices_to_send) +
+           MemoryConsumption::memory_consumption(interpolation_index_of_cells);
+  }
+
+  std::pair<const DoFHandler<dim> *, unsigned int>
+  get_dof_handler_fine() const override
+  {
+    return std::make_pair(&operator_fine.get_matrix_free().get_dof_handler(),
+                          numbers::invalid_unsigned_int);
+  }
+
+private:
+  const LaplaceOperator::LaplaceOperatorFE<dim, Number> &  operator_fine;
+  const LaplaceOperator::LaplaceOperatorFE<dim, Number> &  operator_coarse;
+  std::vector<unsigned int>                                fine_dof_indices;
+  std::vector<unsigned char>                               all_indices_unconstrained;
+  AlignedVector<Number>                                    prolongation_matrix_data;
+  std::shared_ptr<const Utilities::MPI::Partitioner>       partitioner_coarse_cells;
+  std::vector<unsigned int>                                cell_indices_to_be_read;
+  std::vector<unsigned int>                                cell_indices_to_send;
+  std::vector<dealii::ndarray<std::uint8_t, dim, n_lanes>> interpolation_index_of_cells;
+  mutable std::vector<Number>                              data_sent;
+  mutable std::vector<Number>                              data_received;
+
+  template<int size_fine>
+  void
+  do_prolongate_and_add_on_cell(const unsigned int cell,
+                                VectorType &       dst,
+                                const VectorType & src) const
+  {
+    constexpr int size_coarse = size_fine;
+    AssertDimension(prolongation_matrix_data.size(), size_coarse * size_fine * 3);
+    AssertDimension(prolongation_matrix_data.size(), size_coarse * size_fine * 3);
+    constexpr unsigned int  dofs_per_cell = Utilities::pow(size_fine, dim);
+    VectorizedArray<Number> tmp[dofs_per_cell];
+    Number                  tmp2[dofs_per_cell];
+    VectorizedArray<Number> interpolation_matrix[size_coarse * size_fine];
+    const unsigned int      locally_owned_size = partitioner_coarse_cells->locally_owned_size();
+
+    for(unsigned int v = 0; v < n_lanes; ++v)
+      if(cell_indices_to_be_read[cell * n_lanes + v] < locally_owned_size)
+      {
+        operator_coarse.template read_dof_values_compressed<size_coarse - 1>(
+          src,
+          cell_indices_to_be_read[cell * n_lanes + v] / n_lanes,
+          cell_indices_to_be_read[cell * n_lanes + v] % n_lanes,
+          tmp2);
+        for(unsigned int i = 0; i < dofs_per_cell; ++i)
+          tmp[i][v] = tmp2[i];
+      }
+      else if(cell_indices_to_be_read[cell * n_lanes + v] != numbers::invalid_unsigned_int)
+      {
+        const Number * ptr =
+          data_received.data() +
+          (cell_indices_to_be_read[cell * n_lanes + v] - locally_owned_size) * dofs_per_cell;
+        for(unsigned int i = 0; i < dofs_per_cell; ++i)
+          tmp[i][v] = ptr[i];
+      }
+      else
+        for(unsigned int i = 0; i < dofs_per_cell; ++i)
+          tmp[i][v] = 0;
+
+    std::array<unsigned int, n_lanes> indices_interpolation;
+    dealii::internal::EvaluatorTensorProduct<dealii::internal::evaluate_general,
+                                             dim,
+                                             size_coarse,
+                                             size_fine,
+                                             VectorizedArray<Number>>
+      evaluator;
+    for(unsigned int v = 0; v < n_lanes; ++v)
+      indices_interpolation[v] = interpolation_index_of_cells[cell][0][v];
+    vectorized_load_and_transpose(size_coarse * size_fine,
+                                  prolongation_matrix_data.data(),
+                                  indices_interpolation.data(),
+                                  interpolation_matrix);
+    evaluator.template apply<0, true, false>(interpolation_matrix, tmp, tmp);
+    if constexpr(dim > 1)
+    {
+      for(unsigned int v = 0; v < n_lanes; ++v)
+        indices_interpolation[v] = interpolation_index_of_cells[cell][1][v];
+      vectorized_load_and_transpose(size_coarse * size_fine,
+                                    prolongation_matrix_data.data(),
+                                    indices_interpolation.data(),
+                                    interpolation_matrix);
+      evaluator.template apply<1, true, false>(interpolation_matrix, tmp, tmp);
+    }
+    if constexpr(dim > 2)
+    {
+      for(unsigned int v = 0; v < n_lanes; ++v)
+        indices_interpolation[v] = interpolation_index_of_cells[cell][2][v];
+      vectorized_load_and_transpose(size_coarse * size_fine,
+                                    prolongation_matrix_data.data(),
+                                    indices_interpolation.data(),
+                                    interpolation_matrix);
+      evaluator.template apply<2, true, false>(interpolation_matrix, tmp, tmp);
+    }
+
+    operator_fine.template distribute_local_to_global_compressed<size_fine - 1, size_fine, 1>(
+      dst, fine_dof_indices, all_indices_unconstrained, cell, {}, true, tmp);
+  }
+
+  template<int size_fine>
+  void
+  do_restrict_and_add_on_cell(const unsigned int cell,
+                              VectorType &       dst,
+                              const VectorType & src) const
+  {
+    constexpr int size_coarse = size_fine;
+    AssertDimension(prolongation_matrix_data.size(), size_coarse * size_fine * 3);
+    AssertDimension(prolongation_matrix_data.size(), size_coarse * size_fine * 3);
+    constexpr unsigned int  dofs_per_cell = Utilities::pow(size_fine, dim);
+    VectorizedArray<Number> tmp[dofs_per_cell];
+    Number                  tmp2[dofs_per_cell];
+    VectorizedArray<Number> interpolation_matrix[size_coarse * size_fine];
+
+    operator_fine.template read_dof_values_compressed<size_fine - 1, size_fine, 1>(
+      src, fine_dof_indices, all_indices_unconstrained, cell, {}, true, tmp);
+    std::array<unsigned int, n_lanes> indices_interpolation;
+    dealii::internal::EvaluatorTensorProduct<dealii::internal::evaluate_general,
+                                             dim,
+                                             size_coarse,
+                                             size_fine,
+                                             VectorizedArray<Number>>
+      evaluator;
+    for(unsigned int v = 0; v < n_lanes; ++v)
+      indices_interpolation[v] = interpolation_index_of_cells[cell][0][v];
+    vectorized_load_and_transpose(size_coarse * size_fine,
+                                  prolongation_matrix_data.data(),
+                                  indices_interpolation.data(),
+                                  interpolation_matrix);
+    evaluator.template apply<0, false, false>(interpolation_matrix, tmp, tmp);
+    if constexpr(dim > 1)
+    {
+      for(unsigned int v = 0; v < n_lanes; ++v)
+        indices_interpolation[v] = interpolation_index_of_cells[cell][1][v];
+      vectorized_load_and_transpose(size_coarse * size_fine,
+                                    prolongation_matrix_data.data(),
+                                    indices_interpolation.data(),
+                                    interpolation_matrix);
+      evaluator.template apply<1, false, false>(interpolation_matrix, tmp, tmp);
+    }
+    if constexpr(dim > 2)
+    {
+      for(unsigned int v = 0; v < n_lanes; ++v)
+        indices_interpolation[v] = interpolation_index_of_cells[cell][2][v];
+      vectorized_load_and_transpose(size_coarse * size_fine,
+                                    prolongation_matrix_data.data(),
+                                    indices_interpolation.data(),
+                                    interpolation_matrix);
+      evaluator.template apply<2, false, false>(interpolation_matrix, tmp, tmp);
+    }
+
+    const unsigned int locally_owned_size = partitioner_coarse_cells->locally_owned_size();
+    for(unsigned int v = 0; v < n_lanes; ++v)
+      if(cell_indices_to_be_read[cell * n_lanes + v] < locally_owned_size)
+      {
+        for(unsigned int i = 0; i < dofs_per_cell; ++i)
+          tmp2[i] = tmp[i][v];
+        operator_coarse.template distribute_local_to_global_compressed<size_coarse - 1>(
+          dst,
+          cell_indices_to_be_read[cell * n_lanes + v] / n_lanes,
+          cell_indices_to_be_read[cell * n_lanes + v] % n_lanes,
+          tmp2);
+      }
+      else if(cell_indices_to_be_read[cell * n_lanes + v] != numbers::invalid_unsigned_int)
+      {
+        Number * ptr =
+          data_received.data() +
+          (cell_indices_to_be_read[cell * n_lanes + v] - locally_owned_size) * dofs_per_cell;
+        for(unsigned int i = 0; i < dofs_per_cell; ++i)
+          ptr[i] += tmp[i][v];
+      }
+  }
+};
+
+
+
 template<int dim, typename Number = float>
 class PoissonPreconditionerMG
 {
@@ -123,45 +927,12 @@ public:
       else
         dof_h.distribute_dofs(*fe_hierarchy[level - coarse_triangulations.size() + 1]);
 
-      level_constraints[level].reinit(dof_h.locally_owned_dofs(),
-                                      dealii::DoFTools::extract_locally_relevant_dofs(dof_h));
+      reinit_level_constraints(dof_h,
+                               level + 1 >= coarse_triangulations.size() ?
+                                 cell_vectorization_category :
+                                 std::vector<unsigned int>(),
+                               level_constraints[level]);
 
-      dealii::ndarray<unsigned int, dim, 2> periodic_ids;
-      for(unsigned int d = 0; d < dim; ++d)
-        for(unsigned int e = 0; e < 2; ++e)
-          periodic_ids[d][e] = numbers::invalid_unsigned_int;
-      {
-        for(const auto & cell : dof_h.cell_iterators_on_level(0))
-          for(unsigned int d = 0; d < dim; ++d)
-            if(cell->at_boundary(2 * d) && cell->has_periodic_neighbor(2 * d))
-            {
-              periodic_ids[d][0] = cell->face(2 * d)->boundary_id();
-              periodic_ids[d][1] = cell->periodic_neighbor(2 * d)
-                                     ->face(cell->periodic_neighbor_face_no(2 * d))
-                                     ->boundary_id();
-            }
-        for(unsigned int d = 0; d < dim; ++d)
-          if(periodic_ids[d][0] != numbers::invalid_unsigned_int)
-            dealii::DoFTools::make_periodicity_constraints(
-              dof_h, periodic_ids[d][0], periodic_ids[d][1], d, level_constraints[level]);
-      }
-      level_constraints[level].close();
-
-      typename dealii::MatrixFree<dim, Number>::AdditionalData mf_data;
-      if(level >= coarse_triangulations.size())
-        mf_data.cell_vectorization_category = cell_vectorization_category;
-
-      // renumber Dofs to minimize the number of partitions in import
-      // indices of partitioner
-      dealii::DoFRenumbering::matrix_free_data_locality(dof_h, level_constraints[level], mf_data);
-      level_constraints[level].reinit(dof_h.locally_owned_dofs(),
-                                      dealii::DoFTools::extract_locally_relevant_dofs(dof_h));
-      for(unsigned int d = 0; d < dim; ++d)
-        if(periodic_ids[d][0] != numbers::invalid_unsigned_int)
-          dealii::DoFTools::make_periodicity_constraints(
-            dof_h, periodic_ids[d][0], periodic_ids[d][1], d, level_constraints[level]);
-
-      level_constraints[level].close();
       if(level < coarse_triangulations.size())
       {
         if(mapping_function)
@@ -171,7 +942,9 @@ public:
           mg_matrices[level].reinit(mapping_coarse,
                                     dof_h,
                                     level_constraints[level],
-                                    {},
+                                    level + 1 < coarse_triangulations.size() ?
+                                      std::vector<unsigned int>() :
+                                      cell_vectorization_category,
                                     dealii::QGauss<1>(dof_h.get_fe().degree + 1));
         }
         else
@@ -180,7 +953,9 @@ public:
           mg_matrices[level].reinit(mapping_coarse,
                                     dof_h,
                                     level_constraints[level],
-                                    {},
+                                    level + 1 < coarse_triangulations.size() ?
+                                      std::vector<unsigned int>() :
+                                      cell_vectorization_category,
                                     dealii::QGauss<1>(dof_h.get_fe().degree + 1));
         }
       }
@@ -192,7 +967,14 @@ public:
                                   dealii::QGauss<1>(dof_h.get_fe().degree + 1));
 
       // initialize transfer operator
-      if(level > 0)
+      if(level >= coarse_triangulations.size())
+      {
+        auto transfer =
+          std::make_unique<MGTwoLevelTransferFromOperator<dim, Number>>(mg_matrices[level],
+                                                                        mg_matrices[level - 1]);
+        mg_transfers[level - 1] = std::move(transfer);
+      }
+      else if(level > 0)
       {
         auto transfer = std::make_unique<dealii::MGTwoLevelTransfer<dim, VectorType>>();
         transfer->reinit(dof_h,
@@ -207,6 +989,228 @@ public:
       }
     }
 
+    reinit_smoothers_and_dg(mapping_fine, dof_handler, ip_factor, cell_vectorization_category);
+  }
+
+  PoissonPreconditionerMG(
+    const dealii::Mapping<dim> &                                   mapping_fine,
+    const dealii::DoFHandler<dim> &                                dof_handler,
+    const std::vector<unsigned int> &                              cell_vectorization_category,
+    const std::vector<std::shared_ptr<const Triangulation<dim>>> & coarser_triangulations,
+    const std::vector<std::shared_ptr<const Mapping<dim>>> &       coarser_mappings,
+    const std::function<std::vector<dealii::Point<dim>>(
+      typename dealii::Triangulation<dim>::cell_iterator const)> & mapping_function,
+    const Number                                                   ip_factor,
+    const bool                                                     is_test)
+    : coarse_triangulations(
+        dealii::
+          MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(coarser_triangulations
+                                                                                      .size() > 0 ?
+                                                                                  *coarser_triangulations
+                                                                                     .back() :
+                                                                                  dof_handler
+                                                                                    .get_triangulation() /*,
+dealii::RepartitioningPolicyTools::MinimalGranularityPolicy<dim>(64)*/)),
+      fe_hierarchy(create_fe_hierarchy(dof_handler.get_fe())),
+      min_level(0),
+      max_level(coarser_triangulations.size() + dof_handler.get_triangulation().n_global_levels() -
+                1 + fe_hierarchy.max_level()),
+      is_test(is_test)
+  {
+    dof_handler_hierarchy.resize(min_level, max_level);
+
+    level_constraints.resize(min_level, max_level);
+    mg_matrices.resize(min_level, max_level);
+    mg_smoother.resize(min_level, max_level);
+    mg_transfers.resize(min_level, max_level);
+    rhs.resize(min_level, max_level);
+    temp_vector.resize(min_level, max_level);
+    solution_update.resize(min_level, max_level);
+
+    unsigned int n_final_geometric_levels     = coarser_triangulations.size();
+    int          index_coarser_triangulations = coarser_triangulations.size() - 1;
+    while(index_coarser_triangulations > 0)
+    {
+      // the last index has already been added, so work on next level
+      --index_coarser_triangulations;
+      coarse_triangulations.push_back(coarser_triangulations[index_coarser_triangulations]);
+    }
+    if(n_final_geometric_levels > 0)
+      coarse_triangulations.emplace_back(&dof_handler.get_triangulation(), [](auto *) {
+        // empty deleter, since fine_triangulation_in is an external field
+        // and its destructor is called somewhere else
+      });
+
+    // initialize levels
+    for(unsigned int level = min_level; level <= max_level; level++)
+    {
+      dealii::AffineConstraints<Number> constraints;
+      dealii::DoFHandler<dim> &         dof_h = dof_handler_hierarchy[level];
+      dealii::MappingQ1<dim>            mapping_q1;
+      dealii::MappingQCache<dim>        mapping_q1_cache(1);
+      const dealii::Mapping<dim> *      mapping = nullptr;
+      if(level < coarser_triangulations.back()->n_global_levels())
+      {
+        dof_h.reinit(*coarse_triangulations[level]);
+        dof_h.distribute_dofs(*fe_hierarchy[0]);
+        if(mapping_function)
+        {
+          mapping_q1_cache.initialize(dof_h.get_triangulation(), mapping_function);
+          mapping = &mapping_q1_cache;
+        }
+        else
+          mapping = &mapping_q1;
+      }
+      else if(level <= max_level - n_final_geometric_levels)
+      {
+        dof_h.reinit(
+          *coarse_triangulations[coarse_triangulations.size() - 1 - n_final_geometric_levels]);
+        dof_h.distribute_dofs(
+          *fe_hierarchy[level - coarse_triangulations.size() + 1 + n_final_geometric_levels]);
+        if(n_final_geometric_levels > 0)
+          mapping = coarser_mappings.back().get();
+        else
+          mapping = &mapping_fine;
+      }
+      else
+      {
+        dof_h.reinit(*coarse_triangulations[level - fe_hierarchy.max_level()]);
+        dof_h.distribute_dofs(*fe_hierarchy.back());
+        if(level == max_level)
+          mapping = &mapping_fine;
+        else
+          mapping = coarser_mappings[max_level - 1 - level].get();
+      }
+
+      reinit_level_constraints(dof_h,
+                               level < max_level ? std::vector<unsigned int>() :
+                                                   cell_vectorization_category,
+                               level_constraints[level]);
+
+      mg_matrices[level].reinit(*mapping,
+                                dof_h,
+                                level_constraints[level],
+                                level < max_level ? std::vector<unsigned int>() :
+                                                    cell_vectorization_category,
+                                dealii::QGauss<1>(dof_h.get_fe().degree + 1));
+
+      // initialize transfer operator
+      if(level > 0 && level <= max_level - n_final_geometric_levels)
+      {
+        auto transfer = std::make_unique<dealii::MGTwoLevelTransfer<dim, VectorType>>();
+        transfer->reinit(dof_h,
+                         dof_handler_hierarchy[level - 1],
+                         level_constraints[level],
+                         level_constraints[level - 1]);
+        transfer->enable_inplace_operations_if_possible(
+          mg_matrices[level - 1].get_matrix_free().get_dof_info().vector_partitioner,
+          mg_matrices[level].get_matrix_free().get_dof_info().vector_partitioner);
+
+        mg_transfers[level - 1] = std::move(transfer);
+      }
+      else if(level > max_level - n_final_geometric_levels)
+      {
+        auto transfer = std::make_unique<MGTwoLevelTransferAnisotropicNested<dim, Number>>(
+          mg_matrices[level], mg_matrices[level - 1]);
+        /*
+        MGTwoLevelTransferNonNested<dim, VectorType> transfer_nonnested;
+        MappingQ1<dim>                               mapping;
+        transfer_nonnested.reinit(dof_handler_hierarchy[level],
+                                  dof_handler_hierarchy[level - 1],
+                                  mapping,
+                                  mapping,
+                                  level_constraints[level],
+                                  level_constraints[level - 1]);
+        VectorType v1, v2, v3, v4;
+        mg_matrices[level - 1].initialize_dof_vector(v1);
+        mg_matrices[level - 1].initialize_dof_vector(v4);
+        mg_matrices[level].initialize_dof_vector(v2);
+        mg_matrices[level].initialize_dof_vector(v3);
+        Tensor<1, dim> tens;
+        tens[0] = 1;
+        tens[1] = 1;
+        tens[2] = 1;
+        VectorTools::interpolate(mapping,
+                                 dof_handler_hierarchy[level - 1],
+                                 Functions::Monomial<dim, Number>(tens, 1),
+                                 v1);
+        transfer->prolongate_and_add(v2, v1);
+        transfer_nonnested.prolongate_and_add(v3, v1);
+        std::cout << "Prolongate norms: " << v2.l2_norm() << " " << v3.l2_norm() << " difference ";
+        v2 -= v3;
+        std::cout << v2.l2_norm() << std::endl;
+        v1 = 0;
+        v4 = 0;
+        transfer->restrict_and_add(v1, v3);
+        transfer_nonnested.restrict_and_add(v4, v3);
+        std::cout << "Restrict norms: " << v1.l2_norm() << " " << v4.l2_norm() << " difference ";
+        v1 -= v4;
+        std::cout << v1.l2_norm() << std::endl;
+        */
+        mg_transfers[level - 1] = std::move(transfer);
+      }
+    }
+
+    reinit_smoothers_and_dg(mapping_fine, dof_handler, ip_factor, cell_vectorization_category);
+  }
+
+  void
+  reinit_level_constraints(DoFHandler<dim> &                 dof_h,
+                           const std::vector<unsigned int> & cell_vectorization_category,
+                           AffineConstraints<Number> &       level_constraints)
+  {
+    level_constraints.reinit(dof_h.locally_owned_dofs(),
+                             dealii::DoFTools::extract_locally_relevant_dofs(dof_h));
+
+    dealii::ndarray<unsigned int, dim, 2> periodic_ids;
+    for(unsigned int d = 0; d < dim; ++d)
+      for(unsigned int e = 0; e < 2; ++e)
+        periodic_ids[d][e] = numbers::invalid_unsigned_int;
+    for(const auto & cell : dof_h.cell_iterators_on_level(0))
+      for(unsigned int d = 0; d < dim; ++d)
+        if(cell->at_boundary(2 * d) && cell->has_periodic_neighbor(2 * d))
+        {
+          periodic_ids[d][0] = cell->face(2 * d)->boundary_id();
+          periodic_ids[d][1] = cell->periodic_neighbor(2 * d)
+                                 ->face(cell->periodic_neighbor_face_no(2 * d))
+                                 ->boundary_id();
+        }
+    std::vector<GridTools::PeriodicFacePair<typename DoFHandler<dim>::cell_iterator>>
+      periodic_faces;
+    for(unsigned int d = 0; d < dim; ++d)
+      if(periodic_ids[d][0] != numbers::invalid_unsigned_int)
+        GridTools::collect_periodic_faces(
+          dof_h, periodic_ids[d][0], periodic_ids[d][1], d, periodic_faces);
+    for(const auto & face_pair : periodic_faces)
+      Periodicity::make_periodicity_constraints_recursively(
+        face_pair.cell[0]->face(face_pair.face_idx[0]),
+        face_pair.cell[1]->face(face_pair.face_idx[1]),
+        level_constraints);
+    level_constraints.close();
+
+    typename dealii::MatrixFree<dim, Number>::AdditionalData mf_data;
+    mf_data.cell_vectorization_category = cell_vectorization_category;
+
+    // renumber Dofs to minimize the number of partitions in import
+    // indices of partitioner
+    dealii::DoFRenumbering::matrix_free_data_locality(dof_h, level_constraints, mf_data);
+    level_constraints.reinit(dof_h.locally_owned_dofs(),
+                             dealii::DoFTools::extract_locally_relevant_dofs(dof_h));
+    for(const auto & face_pair : periodic_faces)
+      Periodicity::make_periodicity_constraints_recursively(
+        face_pair.cell[0]->face(face_pair.face_idx[0]),
+        face_pair.cell[1]->face(face_pair.face_idx[1]),
+        level_constraints);
+
+    level_constraints.close();
+  }
+
+  void
+  reinit_smoothers_and_dg(const Mapping<dim> &              mapping_fine,
+                          const DoFHandler<dim> &           dof_handler,
+                          const Number                      ip_factor,
+                          const std::vector<unsigned int> & cell_vectorization_category)
+  {
     // initialize levels
     for(unsigned int level = min_level; level <= max_level; level++)
     {

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
@@ -235,7 +235,8 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::allocate_vectors()
                                       laplace_op->get_dof_indices());
 
   // depending on whether we have additional grids provided, enter the path
-  // with semi-coarsening possibilities or or
+  // with semi-coarsening possibilities or the standard path with a classical
+  // polynomial/geometric coarsening
   if(pde_operator->get_grid().coarse_triangulations.empty())
     poisson_preconditioner = std::make_shared<LaplaceOperator::PoissonPreconditionerMG<dim, float>>(
       *pde_operator->get_mapping(),

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
@@ -234,13 +234,26 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::allocate_vectors()
   op_rt->initialize_coupling_pressure(pde_operator->get_dof_handler_p().get_fe(),
                                       laplace_op->get_dof_indices());
 
-  poisson_preconditioner = std::make_shared<LaplaceOperator::PoissonPreconditionerMG<dim, float>>(
-    *pde_operator->get_mapping(),
-    pde_operator->get_dof_handler_p(),
-    cell_vectorization_category,
-    pde_operator->get_grid().mapping_function,
-    pde_operator->laplace_operator.get_data().kernel_data.IP_factor,
-    this->is_test);
+  // depending on whether we have additional grids provided, enter the path
+  // with semi-coarsening possibilities or or
+  if(pde_operator->get_grid().coarse_triangulations.empty())
+    poisson_preconditioner = std::make_shared<LaplaceOperator::PoissonPreconditionerMG<dim, float>>(
+      *pde_operator->get_mapping(),
+      pde_operator->get_dof_handler_p(),
+      cell_vectorization_category,
+      pde_operator->get_grid().mapping_function,
+      pde_operator->laplace_operator.get_data().kernel_data.IP_factor,
+      this->is_test);
+  else
+    poisson_preconditioner = std::make_shared<LaplaceOperator::PoissonPreconditionerMG<dim, float>>(
+      *pde_operator->get_mapping(),
+      pde_operator->get_dof_handler_p(),
+      cell_vectorization_category,
+      pde_operator->get_grid().coarse_triangulations,
+      pde_operator->get_grid().coarse_mappings,
+      pde_operator->get_grid().mapping_function,
+      pde_operator->laplace_operator.get_data().kernel_data.IP_factor,
+      this->is_test);
 
   for(unsigned int i = 0; i < pressure.size(); ++i)
     poisson_preconditioner->get_dg_matrix().initialize_dof_vector(pressure[i]);

--- a/include/exadg/operators/constraints.h
+++ b/include/exadg/operators/constraints.h
@@ -23,13 +23,64 @@
 #define EXADG_OPERATORS_CONSTRAINTS_H_
 
 // deal.II
+#include <deal.II/base/std_cxx20/type_traits.h>
 #include <deal.II/dofs/dof_tools.h>
+#include <deal.II/lac/affine_constraints.h>
 
 // ExaDG
 #include <exadg/grid/grid_utilities.h>
 
 namespace ExaDG
 {
+// Manually implement periodicity constraints, because the deal.II
+// implementation places the constraints the 'wrong' way around, leading to a
+// case with more unknowns on the processor with the lower rank and less on
+// the higher ranks. This function constrains the unknown on the lower-left
+// boundary by the one on the upper-right boundary. This is coherent with the
+// strategy that DoFs on interfaces of two processes are assigned to the
+// process with lower rank.
+namespace Periodicity
+{
+template<typename FaceIterator, typename Number>
+void
+make_periodicity_constraints_recursively(
+  const FaceIterator &                                     face_1,
+  const dealii::std_cxx20::type_identity_t<FaceIterator> & face_2,
+  dealii::AffineConstraints<Number> &                      affine_constraints)
+{
+  if(face_1->has_children())
+  {
+    if(!face_2->has_children())
+      return;
+    for(unsigned int i = 0; i < face_1->n_children(); ++i)
+      make_periodicity_constraints_recursively(face_1->child(i),
+                                               face_2->child(i),
+                                               affine_constraints);
+  }
+  else
+  {
+    const unsigned int dofs_per_face = face_1->get_fe(0).n_dofs_per_face(0);
+    std::vector<dealii::types::global_dof_index> dofs_1(dofs_per_face);
+    std::vector<dealii::types::global_dof_index> dofs_2(dofs_per_face);
+
+    face_1->get_dof_indices(dofs_1, 0);
+    face_2->get_dof_indices(dofs_2, 0);
+    for(unsigned int i = 0; i < dofs_per_face; ++i)
+      if(dofs_1[i] == dealii::numbers::invalid_dof_index ||
+         dofs_2[i] == dealii::numbers::invalid_dof_index)
+        return;
+    for(unsigned int i = 0; i < dofs_per_face; ++i)
+    {
+      if(!affine_constraints.is_constrained(dofs_1[i]))
+        affine_constraints.add_constraint(dofs_1[i], {{dofs_2[i], 1.0}});
+    }
+  }
+}
+
+} // namespace Periodicity
+
+
+
 /**
  * This function adds hanging-node and periodicity constraints. This function combines these two
  * types of constraints since deal.II requires to add these constraints in a certain order.


### PR DESCRIPTION
This implements two new transfer operators for DG. One is one that avoids weighting + adding in prolongation, leading to somewhat better data locality and thus higher speed. The second one is the main achievement of this (arguably big) pull request: I implement the option to perform semi-coarsening, which is a variant designed for boundary-layer adapted meshes. Instead of isotropically coarsening in all directions, the multigrid theory suggests that one should only coarsen in the direction of short edges, called "semi-coarsening". We could already do this with the `MGTwoLevelTransferNonNested` of deal.II, but that is a slow approach because it does entirely unstructed transfer. With this class, we do a more optimized variant that does construct the embedding in a nested way. We still do a geometric search, because we use two entirely independent triangulations, but we just identify one point per cell (the center on the refined side) and match it with the coarse grid, rather than every single support point of the polynomial.

One could do further optimizations, like mesh coarsening in the part of the triangulation not part of the semi-coarsening process, and with the optimized transfer classes also merge the "residual" computation with the "transfer::restrict_and_add" function into a single function, thus leading to one less communication step. But this PR is already very big, so I postpone all further optimizations.

That said, I already added it to the periodic hill case. Whereas the pressure Poisson solver would previously take 5 iterations (on average over 200k time steps), I believe the new code will arrive under 2 iterations per solve. I'm still running the time steps, so I only have a few snapshots to base my judgement on, but except for the first 4 times where I need to build up the initial guesses for the projection, I see only 1 or 2 iterations taken. This is an exceptional improvement.