### PR TITLE
Allow to actually input degree 0

### DIFF
--- a/include/exadg/operators/resolution_parameters.h
+++ b/include/exadg/operators/resolution_parameters.h
@@ -56,7 +56,7 @@ struct SpatialResolutionParametersMinMax
       prm.add_parameter("DegreeMax",
                         degree_max,
                         "Maximal polynomial degree of shape functions.",
-                        dealii::Patterns::Integer(1),
+                        dealii::Patterns::Integer(0),
                         false);
       prm.add_parameter("RefineSpaceMin",
                         refine_space_min,
@@ -72,7 +72,7 @@ struct SpatialResolutionParametersMinMax
     prm.leave_subsection();
   }
 
-  unsigned int degree_min = 0;
+  unsigned int degree_min = 1;
   unsigned int degree_max = 0;
 
   unsigned int refine_space_min = 0;


### PR DESCRIPTION
@richardschu: With our code merged from #38 I observed an error:
```
terminate called after throwing an instance of 'dealii::Patterns::Tools::ExcNoMatch'
  what():  
--------------------------------------------------------
An error occurred in line <1532> of file </home/martin/deal/deal.II/include/deal.II/base/patterns.h> in function
    static std::string dealii::Patterns::Tools::Convert<unsigned int>::to_string(const T &, const Patterns::PatternBase &) [T = unsigned int, Enable = void]
The violated condition was: 
    p.match(str.str())
Additional information: 
    The string "0" does not match the pattern "[Integer range
    1...2147483647 (inclusive)]"
```

We should make sure that the parameter for the `max_degree`, which can be left blank, also is allowed to take the value 0.

On the other hand, I believe not allowing degree 0 for the min degree is good, so I go with 1 there.