### PR TITLE
Reduce memory allocations for timer tree

### DIFF
--- a/include/exadg/time_integration/time_int_base.cpp
+++ b/include/exadg/time_integration/time_int_base.cpp
@@ -79,7 +79,6 @@ void
 TimeIntBase::advance_one_timestep_pre_solve(bool const print_header)
 {
   dealii::Timer timer;
-  timer.restart();
 
   if(started() and not finished())
   {
@@ -95,28 +94,26 @@ TimeIntBase::advance_one_timestep_pre_solve(bool const print_header)
     do_timestep_pre_solve(print_header);
   }
 
-  timer_tree->insert({"Timeloop"}, timer.wall_time());
+  timer_tree->insert_leaf("Timeloop", timer.wall_time());
 }
 
 void
 TimeIntBase::advance_one_timestep_solve()
 {
   dealii::Timer timer;
-  timer.restart();
 
   if(started() and not finished())
   {
     do_timestep_solve();
   }
 
-  timer_tree->insert({"Timeloop"}, timer.wall_time());
+  timer_tree->insert_leaf("Timeloop", timer.wall_time());
 }
 
 void
 TimeIntBase::advance_one_timestep_post_solve()
 {
   dealii::Timer timer;
-  timer.restart();
 
   if(started() and not finished())
   {
@@ -130,7 +127,7 @@ TimeIntBase::advance_one_timestep_post_solve()
     time += get_time_step_size();
   }
 
-  timer_tree->insert({"Timeloop"}, timer.wall_time());
+  timer_tree->insert_leaf("Timeloop", timer.wall_time());
 }
 
 void

--- a/include/exadg/utilities/timer_tree.cpp
+++ b/include/exadg/utilities/timer_tree.cpp
@@ -44,24 +44,45 @@ TimerTree::clear()
 }
 
 void
-TimerTree::insert(std::vector<std::string> const ids, double const wall_time)
+TimerTree::insert_leaf(std::string const & id, double const wall_time)
+{
+  if(this->id == "") // the tree is currently empty
+  {
+    AssertThrow(sub_trees.empty(), dealii::ExcMessage("invalid state found. aborting."));
+
+    this->id = id;
+
+    data = std::make_shared<Data>();
+    data->wall_time += wall_time;
+  }
+  else if(this->id == id) // the tree already has some entries
+  {
+    if(data.get() == nullptr)
+      data = std::make_shared<Data>();
+
+    data->wall_time += wall_time;
+  }
+  else // the provided name does not fit to this tree
+  {
+    AssertThrow(false,
+                dealii::ExcMessage("The name provided is " + id + ", but must be " + this->id +
+                                   " instead."));
+  }
+}
+
+void
+TimerTree::insert(std::vector<std::string> const & ids, double const wall_time)
 {
   AssertThrow(ids.size() > 0, dealii::ExcMessage("empty name."));
-
-  if(this->id == "") // the tree is currently empty
+  if(ids.size() == 1)
+    insert_leaf(ids[0], wall_time);
+  else if(this->id == "") // the tree is currently empty
   {
     AssertThrow(sub_trees.empty(), dealii::ExcMessage("invalid state found. aborting."));
 
     this->id = ids[0];
 
-    if(ids.size() == 1) // leaves of tree reached, insert the data
-    {
-      data = std::make_shared<Data>();
-      data->wall_time += wall_time;
-
-      return;
-    }
-    else // go deeper
+    // have several levels, go deeper
     {
       std::vector<std::string> remaining_id = erase_first(ids);
 
@@ -72,16 +93,7 @@ TimerTree::insert(std::vector<std::string> const ids, double const wall_time)
   }
   else if(this->id == ids[0]) // the tree already has some entries
   {
-    if(ids.size() == 1) // leaves of tree reached, insert the data
-    {
-      if(data.get() == nullptr)
-        data = std::make_shared<Data>();
-
-      data->wall_time += wall_time;
-
-      return;
-    }
-    else // find correct sub-tree or insert new sub-tree
+    // find correct sub-tree or insert new sub-tree
     {
       std::vector<std::string> remaining_id = erase_first(ids);
 
@@ -114,9 +126,9 @@ TimerTree::insert(std::vector<std::string> const ids, double const wall_time)
 }
 
 void
-TimerTree::insert(std::vector<std::string>   ids,
-                  std::shared_ptr<TimerTree> sub_tree,
-                  std::string const          new_name)
+TimerTree::insert(std::vector<std::string> const &   ids,
+                  std::shared_ptr<TimerTree> const & sub_tree,
+                  std::string const                  new_name)
 {
   AssertThrow(ids.size() > 0, dealii::ExcMessage("Empty ID specified."));
   AssertThrow(id == ids[0], dealii::ExcMessage("Invalid ID specified."));
@@ -211,7 +223,9 @@ TimerTree::get_max_level() const
 void
 TimerTree::copy_from(std::shared_ptr<TimerTree> other)
 {
-  *this = *other;
+  id        = other->id;
+  data      = other->data;
+  sub_trees = other->sub_trees;
 }
 
 std::vector<std::string>

--- a/include/exadg/utilities/timer_tree.h
+++ b/include/exadg/utilities/timer_tree.h
@@ -54,19 +54,28 @@ public:
    * entry already existing in the tree.
    */
   void
-  insert(std::vector<std::string> const ids, double const wall_time);
+  insert(std::vector<std::string> const & ids, double const wall_time);
+
+  /**
+   * This function inserts a measured wall_time into the tree, by
+   * either creating a new entry in the tree if this function is called
+   * the first time with this ID, or by adding the wall_time to an
+   * entry already existing in the tree.
+   */
+  void
+  insert_leaf(std::string const & id, double const wall_time);
 
   /**
    * This function inserts a whole sub_tree into an existing tree, where
    * the parameter names specifies the place at which to insert the sub_tree.
    * This function allows to combine different timer trees in a modular way.
-   * If a non empty string new_name is provided, the id of  sub_tree is
+   * If a non empty string new_name is provided, the id of sub_tree is
    * replaced by new_name when inserted into the tree.
    */
   void
-  insert(std::vector<std::string>   ids,
-         std::shared_ptr<TimerTree> sub_tree,
-         std::string const          new_name = "");
+  insert(std::vector<std::string> const &   ids,
+         std::shared_ptr<TimerTree> const & sub_tree,
+         std::string const                  new_name = "");
 
   /**
    * Prints wall time of all items of a tree without an analysis of
@@ -193,8 +202,8 @@ private:
 
   std::vector<std::shared_ptr<TimerTree>> sub_trees;
 
-  static unsigned int const offset_per_level = 2;
-  static unsigned int const precision        = 2;
+  unsigned int const offset_per_level = 2;
+  unsigned int const precision        = 2;
 };
 } // namespace ExaDG
 


### PR DESCRIPTION
I noticed a high number of memory allocations. This is a first step to reduce the allocations somewhat: 
- Pass arguments by const reference, not by value, to avoid a copy upon function entry.
- For a single-depth timer value, provide a specialized `insert_leaf` function that avoids creating a vector with one entry.
- Avoid some static variable.

This is not the state in which I'd like to have the timer facilities, because we still do a few things that are questionable, especially the `erase_first(std::vector<std::string> &ids);` functions that are indicating the use of an inappropriate data structure for the task in question, but it is a step forward. Maybe I have the time in the near future to look at it again.