### PR TITLE
Avoid initializing an unnecessary data structure

### DIFF
--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -69,7 +69,7 @@ MomentumOperator<dim, Number>::initialize(
                                  operator_data.viscous_kernel_data,
                                  operator_data.dof_index,
                                  operator_data.quad_index,
-                                 true,
+                                 true /* compute_penalty_parameter */,
                                  use_velocity_own_storage_viscous_kernel);
 
     // initialize and check turbulence model data

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/momentum_operator.cpp
@@ -69,6 +69,7 @@ MomentumOperator<dim, Number>::initialize(
                                  operator_data.viscous_kernel_data,
                                  operator_data.dof_index,
                                  operator_data.quad_index,
+                                 true,
                                  use_velocity_own_storage_viscous_kernel);
 
     // initialize and check turbulence model data

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/operators/viscous_operator.h
@@ -81,6 +81,7 @@ public:
          ViscousKernelData const &               data,
          unsigned int const                      dof_index,
          unsigned int const                      quad_index,
+         bool const                              compute_penalty_parameter,
          bool const                              use_velocity_own_storage)
   {
     this->data                     = data;
@@ -90,7 +91,8 @@ public:
     dealii::FiniteElement<dim> const & fe = matrix_free.get_dof_handler(dof_index).get_fe();
     this->degree                          = fe.degree;
 
-    calculate_penalty_parameter(matrix_free, dof_index);
+    if(compute_penalty_parameter)
+      calculate_penalty_parameter(matrix_free, dof_index);
 
     AssertThrow(data.viscosity >= 0.0, dealii::ExcMessage("Viscosity is not set!"));
 

--- a/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
+++ b/include/exadg/incompressible_navier_stokes/spatial_discretization/spatial_operator_base.cpp
@@ -656,11 +656,14 @@ SpatialOperatorBase<dim, Number>::initialize_operators(std::string const & dof_i
                                                        not param.non_explicit_convective_problem();
 
   viscous_kernel = std::make_shared<Operators::ViscousKernel<dim, Number>>();
-  viscous_kernel->reinit(*matrix_free,
-                         viscous_kernel_data,
-                         get_dof_index_velocity(),
-                         get_quad_index_velocity_standard(),
-                         use_velocity_own_storage_viscous_kernel);
+  viscous_kernel->reinit(
+    *matrix_free,
+    viscous_kernel_data,
+    get_dof_index_velocity(),
+    get_quad_index_velocity_standard(),
+    (param.temporal_discretization != TemporalDiscretization::BDFDualSplittingExtruded &&
+     param.temporal_discretization != TemporalDiscretization::BDFConsistentSplittingExtruded),
+    use_velocity_own_storage_viscous_kernel);
 
   // initialize and check turbulence model data
   if(param.turbulence_model_data.is_active)


### PR DESCRIPTION
We do not need the penalty parameter of the symmetric interior penalty method in case we use the faster non-matrix-free based solvers, which have their own data structure for this.