### PR TITLE
Try running SolverCG in single precision first

### DIFF
--- a/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
+++ b/include/exadg/incompressible_navier_stokes/time_integration/poisson_solver.h
@@ -1369,18 +1369,80 @@ dealii::RepartitioningPolicyTools::MinimalGranularityPolicy<dim>(64)*/)),
   void
   vmult(VectorTypeOuter & dst, const VectorTypeOuter & src) const
   {
+    if constexpr(std::is_same_v<VectorTypeOuter, VectorType>)
+    {
+      do_vcycle(true, src, dst);
+    }
+    else
+    {
+      Timer time;
+      rhs_dg.copy_locally_owned_data_from(src);
+      timings.back()[0] += time.wall_time();
+
+      do_vcycle(true, rhs_dg, solution_update_dg);
+
+      time.restart();
+      dst.copy_locally_owned_data_from(solution_update_dg);
+      timings.back()[0] += time.wall_time();
+    }
+  }
+
+  template<typename VectorTypeOuter, typename MatrixTypeOuter>
+  std::pair<unsigned int, double>
+  solve(const MatrixTypeOuter & matrix,
+        const VectorTypeOuter & rhs,
+        VectorTypeOuter &       sol,
+        const unsigned int      n_max_iterations,
+        const double            target_residual) const
+  {
+    VectorTypeOuter tmp;
+    tmp.reinit(sol, true);
+    matrix.vmult(
+      tmp,
+      sol,
+      [&tmp](const unsigned int begin, const unsigned int end) {
+        std::fill(tmp.begin() + begin, tmp.begin() + end, typename VectorTypeOuter::value_type(0));
+      },
+      [&](const unsigned int begin, const unsigned int end) {
+        DEAL_II_OPENMP_SIMD_PRAGMA
+        for(unsigned int i = begin; i < end; ++i)
+        {
+          rhs_dg.local_element(i)             = rhs.local_element(i) - tmp.local_element(i);
+          solution_update_dg.local_element(i) = 0.;
+        }
+      });
+
+    dealii::IterationNumberControl control(n_max_iterations, target_residual);
+    dealii::SolverCG<VectorType>   solver_cg(control);
+    solver_cg.solve(dg_matrix, solution_update_dg, rhs_dg, *this);
+    DEAL_II_OPENMP_SIMD_PRAGMA
+    for(unsigned int i = 0; i < solution_update_dg.locally_owned_size(); ++i)
+      sol.local_element(i) += solution_update_dg.local_element(i);
+
+    return {control.last_step(), control.last_value()};
+  }
+
+  const MatrixTypeDG &
+  get_dg_matrix() const
+  {
+    return dg_matrix;
+  }
+
+private:
+  void
+  do_vcycle(const bool zero_out_solution, const VectorType & src_rhs, VectorType & solution) const
+  {
     ++count_times;
     Timer time;
-    rhs_dg.copy_locally_owned_data_from(src);
-    timings.back()[0] += time.wall_time();
-    time.restart();
-
-    mg_smoother_dg.vmult(solution_update_dg, rhs_dg);
+    if(zero_out_solution)
+      mg_smoother_dg.vmult(solution, src_rhs);
+    else
+      mg_smoother_dg.step(solution, src_rhs);
     timings.back()[1] += time.wall_time();
     time.restart();
 
-    dg_matrix.vmult_residual_and_restrict_to_fe(rhs_dg,
-                                                solution_update_dg,
+    dg_matrix.vmult_residual_and_restrict_to_fe(src_rhs,
+                                                solution,
                                                 mg_matrices[max_level],
                                                 rhs[max_level]);
     timings.back()[2] += time.wall_time();
@@ -1421,27 +1483,14 @@ dealii::RepartitioningPolicyTools::MinimalGranularityPolicy<dim>(64)*/)),
       timings[level + 1][1] += time.wall_time();
       time.restart();
     }
-    dg_matrix.prolongate_and_add(solution_update_dg,
-                                 solution_update[max_level],
-                                 mg_matrices[max_level]);
+    dg_matrix.prolongate_and_add(solution, solution_update[max_level], mg_matrices[max_level]);
     timings.back()[3] += time.wall_time();
     time.restart();
 
-    mg_smoother_dg.step(solution_update_dg, rhs_dg);
+    mg_smoother_dg.step(solution, src_rhs);
     timings.back()[1] += time.wall_time();
-    time.restart();
-
-    dst.copy_locally_owned_data_from(solution_update_dg);
-    timings.back()[0] += time.wall_time();
   }
 
-  const MatrixTypeDG &
-  get_dg_matrix() const
-  {
-    return dg_matrix;
-  }
-
-private:
   std::vector<std::shared_ptr<const dealii::Triangulation<dim>>> coarse_triangulations;
 
   const dealii::MGLevelObject<std::unique_ptr<dealii::FE_Q<dim>>> fe_hierarchy;

--- a/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
+++ b/include/exadg/incompressible_navier_stokes/time_integration/time_int_bdf_consistent_splitting_extruded.cpp
@@ -463,17 +463,30 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::pressure_step()
   const double t_extrapol = timer2.wall_time();
   timer2.restart();
 
-  // solve linear system of equations
-  unsigned int                 n_iter = 0;
-  dealii::SolverControl        control(this->param.solver_data_pressure_poisson.max_iter,
-                                extrapolate_accuracy.first *
-                                  this->param.solver_data_pressure_poisson.rel_tol);
-  dealii::SolverCG<VectorType> solver(control);
-  solver.solve(*laplace_op, pressure_np, pressure_rhs, *poisson_preconditioner);
-  n_iter = control.last_step();
+  // Solve linear system of equations: Try if we can converge in single
+  // precision first, allowing at most 4 iterations (typical value for
+  // expected error reduction). If we fail, use SolverCG in double precision
+  // as the more robust choice.
+  std::pair<unsigned int, double> n_iter{0, 1.};
+  n_iter = poisson_preconditioner->solve(*laplace_op,
+                                         pressure_rhs,
+                                         pressure_np,
+                                         4 /* n_max_iterations */,
+                                         extrapolate_accuracy.first *
+                                           this->param.solver_data_pressure_poisson.rel_tol);
+  if(n_iter.second > extrapolate_accuracy.first * this->param.solver_data_pressure_poisson.rel_tol)
+  {
+    dealii::SolverControl        control(this->param.solver_data_pressure_poisson.max_iter,
+                                  extrapolate_accuracy.first *
+                                    this->param.solver_data_pressure_poisson.rel_tol);
+    dealii::SolverCG<VectorType> solver(control);
+    solver.solve(*laplace_op, pressure_np, pressure_rhs, *poisson_preconditioner);
+    n_iter.first += control.last_step();
+    n_iter.second = control.last_value();
+  }
 
   iterations_pressure.first += 1;
-  iterations_pressure.second += n_iter;
+  iterations_pressure.second += n_iter.first;
   const double t_sol = timer2.wall_time();
 
   // special case: pressure level is undefined
@@ -489,8 +502,8 @@ TimeIntBDFConsistentSplittingExtruded<dim, Number>::pressure_step()
                 << std::endl
                 << "Solve pressure step (projection reduced residual from "
                 << extrapolate_accuracy.first << " to " << extrapolate_accuracy.second
-                << " solve to " << control.last_value() << "):";
-    print_solver_info_linear(this->pcout, n_iter, timer.wall_time());
+                << " solve to " << n_iter.second << "):";
+    print_solver_info_linear(this->pcout, n_iter.first, timer.wall_time());
   }
 
   this->timer_tree->insert({"Timeloop", "Pressure step"}, timer.wall_time());


### PR DESCRIPTION
This implements a more aggressive use of mixed precision. If `SolverCG` just needs to reduce residuals by 2-4 orders of magnitude, which I decided works if we are in 3-4 iterations at most, we can run it in single precision, reducing the memory consumption and memory access somewhat. This uses the same iterative refinement trick as also the mixed-precision momentum solver does. This enables somewhat faster run times on the application cases.